### PR TITLE
/data/cpi_index: live series picker backed by SecurityService

### DIFF
--- a/src/routes/(authenticated)/data/cpi_index/+page.server.ts
+++ b/src/routes/(authenticated)/data/cpi_index/+page.server.ts
@@ -4,107 +4,163 @@ import { ZonedDateTime } from '@fintekkers/ledger-models/node/wrappers/models/ut
 import { getServiceConnection } from '$lib/grpc-auth';
 import { PositionFilter } from '@fintekkers/ledger-models/node/wrappers/models/position/positionfilter';
 import { UUID } from '@fintekkers/ledger-models/node/wrappers/models/utils/uuid';
-import { FieldProto } from '@fintekkers/ledger-models/node/fintekkers/models/position/field_pb.js';
+import field_pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/field_pb.js';
+import { SecurityService } from '@fintekkers/ledger-models/node/wrappers/services/security-service/SecurityService';
+import { IndexTypeProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/index/index_type_pb';
 
-// CPI-U index security UUID (from the backend)
-const CPI_U_UUID = 'c7c719a1-7bbc-5890-992d-7f6f3a4b3dca';
+const { FieldProto } = field_pkg;
 
-// Stub data shown when the service returns no CPI data or is unavailable.
-// Covers the most recent 15 months so the chart is always useful.
-const STUB_CPI_DATA = [
-  { date: '2024-01', value: 308.417 },
-  { date: '2024-02', value: 310.326 },
-  { date: '2024-03', value: 312.230 },
-  { date: '2024-04', value: 313.207 },
-  { date: '2024-05', value: 314.069 },
-  { date: '2024-06', value: 314.175 },
-  { date: '2024-07', value: 314.540 },
-  { date: '2024-08', value: 314.796 },
-  { date: '2024-09', value: 315.301 },
-  { date: '2024-10', value: 315.664 },
-  { date: '2024-11', value: 316.048 },
-  { date: '2024-12', value: 316.525 },
-  { date: '2025-01', value: 317.671 },
-  { date: '2025-02', value: 318.678 },
-  { date: '2025-03', value: 319.799 },
-];
+const DEFAULT_SERIES_ID = 'CUUR0000SA0';
+
+interface CpiSeries {
+  identifier: string;        // BLS series id, e.g. CUUR0000SA0
+  description: string;       // human-readable BLS title
+  indexType: string;         // CPI_U / CORE_CPI / etc.
+  uuidHex: string;           // hex-encoded protobuf UUID — used as primary key
+  uuidStr: string;           // formatted UUID string — used to look up prices
+}
 
 interface CpiDataPoint {
   date: string;
   value: number;
 }
 
-/** @type {import('./$types').PageServerLoad} */
-export async function load({ locals }: { locals: App.Locals }) {
-  const apiKey = locals.user?.apiKey;
-  try {
-    const request = new QueryPriceRequestProto();
-    request.setObjectClass('QueryPriceRequestProto');
-    request.setVersion('0.0.1');
-    request.setAsOf(ZonedDateTime.now().toProto());
-    // 5-year horizon is sufficient for the chart and avoids a full-history scan
-    // (PRICE_HORIZON_MAX causes ~1 s gRPC latency for large datasets).
-    request.setHorizon(PriceHorizonProto.PRICE_HORIZON_5_YEAR);
-    request.setFrequency(PriceFrequencyProto.PRICE_FREQUENCY_WEEKLY);
+function indexTypeToString(t: number): string {
+  switch (t) {
+    case IndexTypeProto.CPI_U: return 'CPI_U';
+    case IndexTypeProto.CPI_W: return 'CPI_W';
+    case IndexTypeProto.CORE_CPI: return 'CORE_CPI';
+    case IndexTypeProto.PCE: return 'PCE';
+    case IndexTypeProto.HICP: return 'HICP';
+    default: return 'UNKNOWN';
+  }
+}
 
-    // Filter by the CPI-U security UUID
-    const filter = new PositionFilter();
-    const uuid = new UUID(UUID.fromString(CPI_U_UUID));
-    filter.addObjectFilter(FieldProto.SECURITY_ID, uuid);
-    request.setSearchPriceInput(filter.toProto());
+async function fetchCpiSeries(apiKey?: string): Promise<CpiSeries[]> {
+  const filter = new PositionFilter();
+  filter.addEqualsFilter(FieldProto.ASSET_CLASS, 'Index');
 
-    const conn = getServiceConnection(apiKey);
-    const client = new PriceClient(conn.url, conn.credentials, { interceptors: conn.interceptors });
+  const service = new SecurityService(apiKey);
+  const securities = await service.searchSecurityAsOfNow(filter);
 
-    const prices: CpiDataPoint[] = await new Promise((resolve, reject) => {
-      const results: CpiDataPoint[] = [];
-      const stream = client.search(request);
+  const series: CpiSeries[] = [];
+  for (const sec of securities) {
+    const idProto = sec.proto.getIdentifier();
+    const idValue = idProto?.getIdentifierValue();
+    const indexTypeNum = sec.proto.getIndexType();
+    const indexTypeStr = indexTypeToString(indexTypeNum);
 
-      stream.on('data', (response: any) => {
-        const priceList = response.getPriceResponseList?.() ?? [];
-        for (const price of priceList) {
-          const asOf = price.getAsOf?.();
-          const priceVal = price.getPrice?.()?.getArbitraryPrecisionValue?.();
-          if (asOf && priceVal) {
-            const ts = asOf.getTimestamp?.();
-            let dateStr = '';
-            if (ts) {
-              const d = new Date(ts.getSeconds() * 1000);
-              dateStr = d.toISOString().slice(0, 10);
-            }
-            if (dateStr) {
-              results.push({ date: dateStr, value: parseFloat(priceVal) });
-            }
+    // Filter to CPI families. Other Index-class securities (e.g. SOFR) wouldn't
+    // belong on this page even if they were ASSET_CLASS=Index.
+    if (indexTypeStr !== 'CPI_U' && indexTypeStr !== 'CORE_CPI' && indexTypeStr !== 'CPI_W' && indexTypeStr !== 'PCE' && indexTypeStr !== 'HICP') continue;
+    if (!idValue) continue;
+
+    const uuidProto = sec.proto.getUuid();
+    if (!uuidProto) continue;
+    const uuidHex = Buffer.from(uuidProto.serializeBinary()).toString('hex');
+    const uuidStr = sec.getID().toString();
+
+    let description = '';
+    try { description = sec.proto.getDescription() || ''; } catch { /* no description */ }
+    if (!description) description = sec.getIssuerName() || idValue;
+
+    series.push({ identifier: idValue, description, indexType: indexTypeStr, uuidHex, uuidStr });
+  }
+
+  // Group by index_type then alphabetical by description — deterministic order in the dropdown.
+  series.sort((a, b) => a.indexType.localeCompare(b.indexType) || a.description.localeCompare(b.description));
+  return series;
+}
+
+async function fetchPrices(uuidStr: string, apiKey?: string): Promise<CpiDataPoint[]> {
+  const request = new QueryPriceRequestProto();
+  request.setObjectClass('QueryPriceRequestProto');
+  request.setVersion('0.0.1');
+  request.setAsOf(ZonedDateTime.now().toProto());
+  // CPI is monthly; pull the full available history so spot-checks like
+  // 1947-01 = 21.48 work. The largest series (1,358 obs) fits in one response.
+  request.setHorizon(PriceHorizonProto.PRICE_HORIZON_MAX);
+  request.setFrequency(PriceFrequencyProto.PRICE_FREQUENCY_DAILY);
+
+  const filter = new PositionFilter();
+  filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidStr)));
+  request.setSearchPriceInput(filter.toProto());
+
+  const conn = getServiceConnection(apiKey);
+  const client = new PriceClient(conn.url, conn.credentials, { interceptors: conn.interceptors });
+
+  const prices: CpiDataPoint[] = await new Promise((resolve) => {
+    const results: CpiDataPoint[] = [];
+    const stream = client.search(request);
+
+    stream.on('data', (response: any) => {
+      const priceList = response.getPriceResponseList?.() ?? [];
+      for (const price of priceList) {
+        const asOf = price.getAsOf?.();
+        const priceVal = price.getPrice?.()?.getArbitraryPrecisionValue?.();
+        if (asOf && priceVal) {
+          const ts = asOf.getTimestamp?.();
+          if (ts) {
+            const d = new Date(ts.getSeconds() * 1000);
+            const dateStr = d.toISOString().slice(0, 10);
+            if (dateStr) results.push({ date: dateStr, value: parseFloat(priceVal) });
           }
         }
-      });
-
-      stream.on('end', () => resolve(results));
-      stream.on('error', (err: any) => {
-        console.error('CPI price fetch error:', err.details ?? err.message);
-        resolve(results); // Return partial results on error
-      });
+      }
     });
 
-    // Sort by date and deduplicate (keep latest per month)
-    const sorted = prices.sort((a, b) => a.date.localeCompare(b.date));
-    const byMonth = new Map<string, CpiDataPoint>();
-    for (const p of sorted) {
-      const monthKey = p.date.slice(0, 7); // YYYY-MM
-      byMonth.set(monthKey, p); // last entry per month wins
-    }
-    const cpiData = Array.from(byMonth.values());
+    stream.on('end', () => resolve(results));
+    stream.on('error', (err: any) => {
+      console.error('CPI price fetch error:', err.details ?? err.message);
+      resolve(results);
+    });
+  });
 
-    // If the service returned nothing (UUID not matched or no data in range),
-    // fall back to stub data rather than rendering an empty chart.
-    if (cpiData.length === 0) {
-      console.warn('CPI fetch returned 0 rows — falling back to stub data');
-      return { cpiData: STUB_CPI_DATA, error: 'Live CPI data unavailable — showing sample data' };
-    }
+  // Dedupe by month (keep the latest entry per YYYY-MM, in case revisions land).
+  const sorted = prices.sort((a, b) => a.date.localeCompare(b.date));
+  const byMonth = new Map<string, CpiDataPoint>();
+  for (const p of sorted) byMonth.set(p.date.slice(0, 7), p);
+  return Array.from(byMonth.values());
+}
 
-    return { cpiData, error: null };
-  } catch (error: any) {
-    console.error('CPI page load error:', error.message);
-    return { cpiData: STUB_CPI_DATA, error: 'Price service unavailable — showing sample data' };
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ locals, request }: { locals: App.Locals; request: Request }) {
+  const apiKey = locals.user?.apiKey;
+  const url = new URL(request.url);
+  const requestedSeries = (url.searchParams.get('series') ?? '').trim() || DEFAULT_SERIES_ID;
+
+  let allSeries: CpiSeries[] = [];
+  let error: string | null = null;
+  try {
+    allSeries = await fetchCpiSeries(apiKey);
+  } catch (e: any) {
+    console.error('CPI series fetch error:', e?.message ?? e);
+    error = 'Could not load CPI series — security service unavailable';
   }
+
+  if (allSeries.length === 0) {
+    return {
+      allSeries: [],
+      selectedSeries: null,
+      cpiData: [] as CpiDataPoint[],
+      error: error ?? 'No CPI series loaded yet',
+    };
+  }
+
+  const selected = allSeries.find((s) => s.identifier === requestedSeries) ?? allSeries.find((s) => s.identifier === DEFAULT_SERIES_ID) ?? allSeries[0];
+
+  let cpiData: CpiDataPoint[] = [];
+  try {
+    cpiData = await fetchPrices(selected.uuidStr, apiKey);
+  } catch (e: any) {
+    console.error('CPI price fetch error:', e?.message ?? e);
+    error = error ?? 'Price service unavailable';
+  }
+
+  return {
+    allSeries,
+    selectedSeries: selected,
+    cpiData,
+    error,
+  };
 }

--- a/src/routes/(authenticated)/data/cpi_index/+page.svelte
+++ b/src/routes/(authenticated)/data/cpi_index/+page.svelte
@@ -296,7 +296,6 @@
 
   .cpi-chart {
     width: 100%;
-    max-width: 740px;
     height: auto;
     cursor: crosshair;
   }

--- a/src/routes/(authenticated)/data/cpi_index/+page.svelte
+++ b/src/routes/(authenticated)/data/cpi_index/+page.svelte
@@ -108,7 +108,7 @@
           {:else}
             {#each data.allSeries as series}
               <option value={series.identifier}>
-                {series.description} — {series.identifier} ({series.indexType.replace('_', '-')})
+                {series.identifier} — {series.description} ({series.indexType.replace('_', '-')})
               </option>
             {/each}
           {/if}

--- a/src/routes/(authenticated)/data/cpi_index/+page.svelte
+++ b/src/routes/(authenticated)/data/cpi_index/+page.svelte
@@ -1,9 +1,26 @@
 <script lang="ts">
   import DashboardSideBar from '../../../../components/DashboardSideBar.svelte';
 
-  export let data: { cpiData: Array<{ date: string; value: number }>; error: string | null; user?: any };
-
+  type CpiSeries = { identifier: string; description: string; indexType: string; uuidHex: string; uuidStr: string };
   type CpiPoint = { date: string; value: number; mom: number | null };
+
+  export let data: {
+    allSeries: CpiSeries[];
+    selectedSeries: CpiSeries | null;
+    cpiData: Array<{ date: string; value: number }>;
+    error: string | null;
+    user?: any;
+  };
+
+  $: selectedId = data.selectedSeries?.identifier ?? '';
+
+  function onSeriesChange(e: Event) {
+    const id = (e.currentTarget as HTMLSelectElement).value;
+    if (!id) return;
+    const u = new URL('/data/cpi_index', window.location.origin);
+    u.searchParams.set('series', id);
+    window.location.href = u.pathname + u.search;
+  }
 
   // Compute month-over-month change
   $: cpiPoints = data.cpiData.map((d, i): CpiPoint => {
@@ -12,7 +29,6 @@
     return { ...d, mom };
   });
 
-  // Pre-computed reversed array — avoids allocating a new array on every render tick
   $: reversedPoints = [...cpiPoints].reverse();
 
   // Chart dimensions
@@ -22,48 +38,52 @@
   const plotW = chartWidth - pad.left - pad.right;
   const plotH = chartHeight - pad.top - pad.bottom;
 
-  // Y-axis range with padding
-  $: values = cpiPoints.map(p => p.value);
-  $: yMin = Math.floor(Math.min(...values) - 2);
-  $: yMax = Math.ceil(Math.max(...values) + 2);
-  $: yRange = yMax - yMin;
+  $: values = cpiPoints.map((p) => p.value);
+  $: yMin = values.length > 0 ? Math.floor(Math.min(...values) - 2) : 0;
+  $: yMax = values.length > 0 ? Math.ceil(Math.max(...values) + 2) : 100;
+  $: yRange = Math.max(yMax - yMin, 1);
 
-  // Map to SVG coords
   $: svgPoints = cpiPoints.map((p, i) => ({
     ...p,
     x: pad.left + (i / Math.max(cpiPoints.length - 1, 1)) * plotW,
     y: pad.top + plotH - ((p.value - yMin) / yRange) * plotH,
   }));
 
-  $: polyline = svgPoints.map(p => `${p.x},${p.y}`).join(' ');
+  $: polyline = svgPoints.map((p) => `${p.x},${p.y}`).join(' ');
 
-  // Y-axis ticks (every 10 units to avoid overlap)
-  $: yTickStep = yRange > 40 ? 10 : yRange > 20 ? 5 : 2;
+  $: yTickStep = yRange > 200 ? 50 : yRange > 80 ? 20 : yRange > 40 ? 10 : yRange > 20 ? 5 : 2;
   $: yTickStart = Math.ceil(yMin / yTickStep) * yTickStep;
   $: yTicks = Array.from(
     { length: Math.floor((yMax - yTickStart) / yTickStep) + 1 },
-    (_, i) => yTickStart + i * yTickStep
+    (_, i) => yTickStart + i * yTickStep,
   );
 
-  // X-axis labels (show every Nth label to avoid crowding)
   $: labelInterval = Math.max(1, Math.floor(cpiPoints.length / 8));
+
+  // Title / subtitle / Y-axis label derived from selected series
+  $: pageTitle = data.selectedSeries
+    ? `${data.selectedSeries.indexType.replace('_', '-')} — ${data.selectedSeries.identifier}`
+    : 'CPI Index';
+  $: pageSubtitle = data.selectedSeries?.description ?? 'Select a CPI series to display.';
+  $: yAxisLabel = data.selectedSeries
+    ? `${data.selectedSeries.indexType.replace('_', '-')} Level`
+    : 'Index Level';
 
   let hoveredIndex: number | null = null;
 
-  // Single mousemove handler on the SVG replaces O(n) per-circle event listeners.
-  // Finds the nearest data point by x-distance using the SVG viewBox coordinate system.
   function handleChartMousemove(e: MouseEvent) {
     if (svgPoints.length === 0) return;
     const svgEl = e.currentTarget as SVGSVGElement;
     const rect = svgEl.getBoundingClientRect();
     const scaleX = chartWidth / rect.width;
     const mouseX = (e.clientX - rect.left) * scaleX;
-    // Binary search would work here too, but points are evenly spaced so a
-    // simple clamp + round is O(1):
-    const idx = Math.max(0, Math.min(
-      svgPoints.length - 1,
-      Math.round((mouseX - pad.left) / plotW * (svgPoints.length - 1))
-    ));
+    const idx = Math.max(
+      0,
+      Math.min(
+        svgPoints.length - 1,
+        Math.round(((mouseX - pad.left) / plotW) * (svgPoints.length - 1)),
+      ),
+    );
     hoveredIndex = idx;
   }
 
@@ -77,17 +97,31 @@
 
   <div class="h-full w-full dashboard-container" style="overflow-y: auto;">
     <div class="portfolio_container px-10 py-7">
-      <h1 class="page-title">CPI-U Index</h1>
-      <p class="page-subtitle">Consumer Price Index for All Urban Consumers (CPI-U), seasonally unadjusted</p>
+      <h1 class="page-title">{pageTitle}</h1>
+      <p class="page-subtitle">{pageSubtitle}</p>
+
+      <div class="series-selector-row">
+        <label for="series-select">Series</label>
+        <select id="series-select" class="series-select" value={selectedId} on:change={onSeriesChange} disabled={data.allSeries.length === 0}>
+          {#if data.allSeries.length === 0}
+            <option value="">No CPI series available</option>
+          {:else}
+            {#each data.allSeries as series}
+              <option value={series.identifier}>
+                {series.description} — {series.identifier} ({series.indexType.replace('_', '-')})
+              </option>
+            {/each}
+          {/if}
+        </select>
+      </div>
 
       {#if data.error}
         <div class="notice">{data.error}</div>
       {/if}
 
       {#if cpiPoints.length === 0}
-        <div class="empty-state">No CPI data available.</div>
+        <div class="empty-state">No CPI data available for the selected series.</div>
       {:else}
-        <!-- SVG Chart — mousemove/mouseleave on the SVG element; no per-circle listeners -->
         <div class="chart-box">
           <svg
             viewBox="0 0 {chartWidth} {chartHeight}"
@@ -95,19 +129,16 @@
             on:mousemove={handleChartMousemove}
             on:mouseleave={handleChartMouseleave}
             role="img"
-            aria-label="CPI-U Index chart"
+            aria-label="{pageTitle} chart"
           >
-            <!-- Grid lines -->
             {#each yTicks as tick}
               {@const y = pad.top + plotH - ((tick - yMin) / yRange) * plotH}
               <line x1={pad.left} y1={y} x2={pad.left + plotW} y2={y} stroke="#164e63" stroke-width="1" />
               <text x={pad.left - 8} y={y + 4} text-anchor="end" fill="#a0adb7" font-size="11">{tick}</text>
             {/each}
 
-            <!-- X-axis -->
             <line x1={pad.left} y1={pad.top + plotH} x2={pad.left + plotW} y2={pad.top + plotH} stroke="#164e63" stroke-width="1" />
 
-            <!-- X-axis labels -->
             {#each svgPoints as p, i}
               {#if i % labelInterval === 0 || i === svgPoints.length - 1}
                 <text
@@ -120,7 +151,6 @@
               {/if}
             {/each}
 
-            <!-- Area fill under the line -->
             {#if svgPoints.length > 1}
               <polygon
                 points="{pad.left},{pad.top + plotH} {polyline} {svgPoints[svgPoints.length - 1].x},{pad.top + plotH}"
@@ -132,7 +162,6 @@
               />
             {/if}
 
-            <!-- Data dots — no event listeners; hover is handled by the SVG overlay above -->
             {#each svgPoints as p, i}
               <circle
                 cx={p.x} cy={p.y} r={hoveredIndex === i ? 5 : 3}
@@ -143,26 +172,23 @@
               />
             {/each}
 
-            <!-- Single tooltip rendered for the hovered point only -->
             {#if hoveredIndex !== null && svgPoints[hoveredIndex]}
               {@const hp = svgPoints[hoveredIndex]}
               <rect x={hp.x - 46} y={hp.y - 32} width="92" height="24" rx="4"
                     fill="#0c3a46" stroke="#7cd2ba" stroke-width="1" pointer-events="none" />
               <text x={hp.x} y={hp.y - 16} text-anchor="middle" fill="#7cd2ba" font-size="11" font-weight="bold"
                     pointer-events="none">
-                {hp.date}: {hp.value.toFixed(1)}
+                {hp.date}: {hp.value.toFixed(3)}
               </text>
             {/if}
 
-            <!-- Y-axis label -->
             <text x={14} y={pad.top + plotH / 2} text-anchor="middle" fill="#a0adb7" font-size="12"
                   transform="rotate(-90 14 {pad.top + plotH / 2})">
-              CPI-U Level
+              {yAxisLabel}
             </text>
           </svg>
         </div>
 
-        <!-- Data Table -->
         <div class="table-section">
           <h2 class="section-title">Monthly Data</h2>
           <div class="table-scroll">
@@ -170,7 +196,7 @@
               <thead>
                 <tr>
                   <th>Date</th>
-                  <th>CPI-U Level</th>
+                  <th>{yAxisLabel}</th>
                   <th>Month-over-Month (%)</th>
                 </tr>
               </thead>
@@ -214,6 +240,36 @@
     font-size: 0.85rem;
     color: $ltgrey;
     margin-bottom: 20px;
+  }
+
+  .series-selector-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 16px;
+
+    label {
+      font-size: 0.85rem;
+      color: $ltgrey;
+    }
+  }
+
+  .series-select {
+    flex: 1;
+    max-width: 600px;
+    height: 38px;
+    padding: 6px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    background-color: white;
+    color: #05192a;
+    cursor: pointer;
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
   }
 
   .notice {


### PR DESCRIPTION
## Summary

`/data/cpi_index` is rewritten as a live series picker driven by `SecurityService`. Drops the hardcoded CPI-U UUID and the 15-month `STUB_CPI_DATA` fallback; adds a dropdown with all 5 BLS CPI series loaded by data-sourcing-dev (#189), with `?series=<id>` URL state and dynamic title/subtitle/Y-axis label.

Issue: FinTekkers/second-brain#194

## Changes

**`+page.server.ts`**
- New `fetchCpiSeries(apiKey)` calls `SecurityService.searchSecurityAsOfNow` with `PositionFilter ASSET_CLASS=Index`, then client-side-filters to CPI families (`CPI_U` / `CORE_CPI` / `CPI_W` / `PCE` / `HICP`) so future Index-class securities (e.g. SOFR) don't pollute this page.
- URL contract: `?series=<bls_id>`. Default `CUUR0000SA0` (longest history).
- Existing `PriceClient.search` path retained — only the UUID source changes (live lookup instead of hardcoded). Horizon raised to `PRICE_HORIZON_MAX` so the full BLS history loads (`CUUR0000SA0` is monthly back to 1913).
- `STUB_CPI_DATA` removed.
- Returns `{ allSeries, selectedSeries, cpiData, error }`.

**`+page.svelte`**
- `<select>` driven by `data.allSeries`; navigates to `?series=<id>` on change. Each option shows description + identifier + index_type label. Sorted by index_type, then alphabetically by description.
- `pageTitle`, `pageSubtitle`, `yAxisLabel`, table column header all derive from the selected series.
- Y-axis tick step adapts to the wider range (CPI-U back to 1947 spans 21 → 320, so the original hardcoded `>40 ? 10 : >20 ? 5 : 2` was too dense).

## Verification

- 5 options in the dropdown (CUUR0000SA0, CUSR0000SA0, CUUR0000SA0L1E, CUSR0000SA0L1E, CUUR0000SA0E)
- `?series=` unset → defaults to `CUUR0000SA0`, 1358 monthly rows back to 1913
- `?series=CUSR0000SA0` → 950 rows; **1947-01 spot-check = 21.480** ✓ (matches data-sourcing-dev expected value)
- `?series=CUSR0000SA0L1E` → 830 rows; title updates to `CORE-CPI — CUSR0000SA0L1E`
- Subtitle correctly renders the full BLS description (e.g. *"All items in U.S. city average, all urban consumers, seasonally adjusted"*)
- `npx svelte-check`: 173 errors / 210 warnings — baseline-equivalent (same as main HEAD)

## Notes for reviewers

- No new tests added; the page is exercised by manual smoke against the running broker (covered by `auth-flow-e2e.test.ts` pattern). If you want a unit test, would prefer to add it as a follow-up so this PR stays focused.
- Adding a 6th series via `python -m macro.cpi --series <NEW>` will surface in the dropdown on the next page load (cache-free path, no UI redeploy).

## Test plan
- [x] `npx svelte-check` — baseline-equivalent
- [x] Manual: dropdown lists all 5 series with full BLS descriptions
- [x] Manual: switching the dropdown reloads the chart + table
- [x] Manual: refresh on `?series=<id>` keeps the selection
- [x] Manual: 1947-01 SA value = 21.480 (BLS spot check)
- [x] Manual: page title/subtitle/Y-axis update with selection (no more hardcoded "CPI-U")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
