### PR TITLE
prices: drop the 1000-row slice cap (full history renders)

### DIFF
--- a/src/routes/(authenticated)/data/prices/+page.server.ts
+++ b/src/routes/(authenticated)/data/prices/+page.server.ts
@@ -109,8 +109,7 @@ export async function load({ locals, request }) {
           price: p.getPrice().toNumber(),
           asOfMs: p.getAsOf().toDateTime().toMillis(),
         }))
-        .sort((a, b) => b.asOfMs - a.asOfMs)
-        .slice(0, 1000);
+        .sort((a, b) => b.asOfMs - a.asOfMs);
     }
   } catch (e: any) {
     priceError = e.details ?? e.message ?? 'Failed to fetch prices';


### PR DESCRIPTION
Sorted descending by date, then `.slice(0, 1000)` was throwing away everything beyond the most recent ~4 trading years. AAPL goes back to 1980-12-12 (10,000 daily bars); the user was only seeing 2022+.

Verified live: `/data/prices` (default AAPL) now renders 10,000 dates from 1980-12-12 to 2026-05-01.

The cap was a defence against an unbounded table back when it had its own scrollbar; PR #110 + #111 made the page-level scroll handle overflow, so the cap is no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)