### PR TITLE
Roll Plotly across cpi_index, treasury_curve, curves

### DIFF
--- a/src/routes/(authenticated)/data/cpi_index/+page.svelte
+++ b/src/routes/(authenticated)/data/cpi_index/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import DashboardSideBar from '../../../../components/DashboardSideBar.svelte';
 
   type CpiSeries = { identifier: string; description: string; indexType: string; uuidHex: string; uuidStr: string };
@@ -22,7 +23,7 @@
     window.location.href = u.pathname + u.search;
   }
 
-  // Compute month-over-month change
+  // Month-over-month change for the table.
   $: cpiPoints = data.cpiData.map((d, i): CpiPoint => {
     const prev = i > 0 ? data.cpiData[i - 1].value : null;
     const mom = prev ? ((d.value - prev) / prev) * 100 : null;
@@ -30,35 +31,6 @@
   });
 
   $: reversedPoints = [...cpiPoints].reverse();
-
-  // Chart dimensions
-  const chartWidth = 740;
-  const chartHeight = 340;
-  const pad = { top: 30, right: 20, bottom: 60, left: 60 };
-  const plotW = chartWidth - pad.left - pad.right;
-  const plotH = chartHeight - pad.top - pad.bottom;
-
-  $: values = cpiPoints.map((p) => p.value);
-  $: yMin = values.length > 0 ? Math.floor(Math.min(...values) - 2) : 0;
-  $: yMax = values.length > 0 ? Math.ceil(Math.max(...values) + 2) : 100;
-  $: yRange = Math.max(yMax - yMin, 1);
-
-  $: svgPoints = cpiPoints.map((p, i) => ({
-    ...p,
-    x: pad.left + (i / Math.max(cpiPoints.length - 1, 1)) * plotW,
-    y: pad.top + plotH - ((p.value - yMin) / yRange) * plotH,
-  }));
-
-  $: polyline = svgPoints.map((p) => `${p.x},${p.y}`).join(' ');
-
-  $: yTickStep = yRange > 200 ? 50 : yRange > 80 ? 20 : yRange > 40 ? 10 : yRange > 20 ? 5 : 2;
-  $: yTickStart = Math.ceil(yMin / yTickStep) * yTickStep;
-  $: yTicks = Array.from(
-    { length: Math.floor((yMax - yTickStart) / yTickStep) + 1 },
-    (_, i) => yTickStart + i * yTickStep,
-  );
-
-  $: labelInterval = Math.max(1, Math.floor(cpiPoints.length / 8));
 
   // Title / subtitle / Y-axis label derived from selected series
   $: pageTitle = data.selectedSeries
@@ -69,27 +41,52 @@
     ? `${data.selectedSeries.indexType.replace('_', '-')} Level`
     : 'Index Level';
 
-  let hoveredIndex: number | null = null;
+  let chartEl: HTMLDivElement;
 
-  function handleChartMousemove(e: MouseEvent) {
-    if (svgPoints.length === 0) return;
-    const svgEl = e.currentTarget as SVGSVGElement;
-    const rect = svgEl.getBoundingClientRect();
-    const scaleX = chartWidth / rect.width;
-    const mouseX = (e.clientX - rect.left) * scaleX;
-    const idx = Math.max(
-      0,
-      Math.min(
-        svgPoints.length - 1,
-        Math.round(((mouseX - pad.left) / plotW) * (svgPoints.length - 1)),
-      ),
-    );
-    hoveredIndex = idx;
-  }
-
-  function handleChartMouseleave() {
-    hoveredIndex = null;
-  }
+  // Identifier changes navigate the page (window.location.href in onSeriesChange),
+  // so onMount fires fresh per visit. No reactive re-render needed.
+  onMount(async () => {
+    if (data.cpiData.length === 0 || !chartEl) return;
+    const Plotly: any = (await import('plotly.js-dist') as any).default ?? (await import('plotly.js-dist'));
+    const trace = {
+      x: data.cpiData.map((d) => d.date),
+      y: data.cpiData.map((d) => d.value),
+      mode: 'lines',
+      line: { color: '#7cd2ba', width: 1.5 },
+      hovertemplate: '%{x}<br>%{y:.3f}<extra></extra>',
+      name: data.selectedSeries?.identifier ?? '',
+    };
+    const layout = {
+      paper_bgcolor: '#0c3a46',
+      plot_bgcolor: '#0c3a46',
+      font: { color: '#a0adb7', size: 11 },
+      margin: { t: 30, r: 20, b: 50, l: 60 },
+      hovermode: 'x unified',
+      xaxis: {
+        gridcolor: '#164e63',
+        rangeslider: { visible: true, bgcolor: '#0a2e38', thickness: 0.05 },
+        rangeselector: {
+          buttons: [
+            { count: 1, label: '1Y', step: 'year', stepmode: 'backward' },
+            { count: 5, label: '5Y', step: 'year', stepmode: 'backward' },
+            { count: 10, label: '10Y', step: 'year', stepmode: 'backward' },
+            { count: 25, label: '25Y', step: 'year', stepmode: 'backward' },
+            { step: 'all', label: 'All' },
+          ],
+          bgcolor: '#0c3a46',
+          activecolor: '#7cd2ba',
+          font: { color: '#a0adb7' },
+          x: 0,
+          y: 1.15,
+        },
+      },
+      yaxis: {
+        gridcolor: '#164e63',
+        title: { text: yAxisLabel, font: { color: '#a0adb7' } },
+      },
+    };
+    Plotly.newPlot(chartEl, [trace], layout, { responsive: true, displayModeBar: false });
+  });
 </script>
 
 <div class="w-screen h-full flex">
@@ -123,70 +120,7 @@
         <div class="empty-state">No CPI data available for the selected series.</div>
       {:else}
         <div class="chart-box">
-          <svg
-            viewBox="0 0 {chartWidth} {chartHeight}"
-            class="cpi-chart"
-            on:mousemove={handleChartMousemove}
-            on:mouseleave={handleChartMouseleave}
-            role="img"
-            aria-label="{pageTitle} chart"
-          >
-            {#each yTicks as tick}
-              {@const y = pad.top + plotH - ((tick - yMin) / yRange) * plotH}
-              <line x1={pad.left} y1={y} x2={pad.left + plotW} y2={y} stroke="#164e63" stroke-width="1" />
-              <text x={pad.left - 8} y={y + 4} text-anchor="end" fill="#a0adb7" font-size="11">{tick}</text>
-            {/each}
-
-            <line x1={pad.left} y1={pad.top + plotH} x2={pad.left + plotW} y2={pad.top + plotH} stroke="#164e63" stroke-width="1" />
-
-            {#each svgPoints as p, i}
-              {#if i % labelInterval === 0 || i === svgPoints.length - 1}
-                <text
-                  x={p.x} y={pad.top + plotH + 18}
-                  text-anchor="middle" fill="#a0adb7" font-size="10"
-                  transform="rotate(-35 {p.x} {pad.top + plotH + 18})"
-                >
-                  {p.date}
-                </text>
-              {/if}
-            {/each}
-
-            {#if svgPoints.length > 1}
-              <polygon
-                points="{pad.left},{pad.top + plotH} {polyline} {svgPoints[svgPoints.length - 1].x},{pad.top + plotH}"
-                fill="rgba(124, 210, 186, 0.15)"
-              />
-              <polyline
-                points={polyline}
-                fill="none" stroke="#7cd2ba" stroke-width="2.5" stroke-linejoin="round"
-              />
-            {/if}
-
-            {#each svgPoints as p, i}
-              <circle
-                cx={p.x} cy={p.y} r={hoveredIndex === i ? 5 : 3}
-                fill={hoveredIndex === i ? '#7cd2ba' : '#0c3a46'}
-                stroke="#7cd2ba" stroke-width="1.5"
-                pointer-events="none"
-                aria-label="{p.date}: {p.value}"
-              />
-            {/each}
-
-            {#if hoveredIndex !== null && svgPoints[hoveredIndex]}
-              {@const hp = svgPoints[hoveredIndex]}
-              <rect x={hp.x - 46} y={hp.y - 32} width="92" height="24" rx="4"
-                    fill="#0c3a46" stroke="#7cd2ba" stroke-width="1" pointer-events="none" />
-              <text x={hp.x} y={hp.y - 16} text-anchor="middle" fill="#7cd2ba" font-size="11" font-weight="bold"
-                    pointer-events="none">
-                {hp.date}: {hp.value.toFixed(3)}
-              </text>
-            {/if}
-
-            <text x={14} y={pad.top + plotH / 2} text-anchor="middle" fill="#a0adb7" font-size="12"
-                  transform="rotate(-90 14 {pad.top + plotH / 2})">
-              {yAxisLabel}
-            </text>
-          </svg>
+          <div bind:this={chartEl} class="cpi-chart" />
         </div>
 
         <div class="table-section">
@@ -201,12 +135,8 @@
                 </tr>
               </thead>
               <tbody>
-                {#each reversedPoints as point, i}
-                  <tr
-                    class:highlight={hoveredIndex === cpiPoints.length - 1 - i}
-                    on:mouseenter={() => hoveredIndex = cpiPoints.length - 1 - i}
-                    on:mouseleave={() => hoveredIndex = null}
-                  >
+                {#each reversedPoints as point}
+                  <tr>
                     <td>{point.date}</td>
                     <td class="value-cell">{point.value.toFixed(3)}</td>
                     <td class="change-cell" class:positive={point.mom !== null && point.mom > 0} class:negative={point.mom !== null && point.mom < 0}>
@@ -296,8 +226,7 @@
 
   .cpi-chart {
     width: 100%;
-    height: auto;
-    cursor: crosshair;
+    min-height: 420px;  // chart + range slider + range selector
   }
 
   .section-title {
@@ -335,7 +264,7 @@
     color: $white;
   }
 
-  tr:hover, .highlight {
+  tr:hover {
     background-color: $bgc-color;
     cursor: default;
   }

--- a/src/routes/(authenticated)/data/curves/+page.svelte
+++ b/src/routes/(authenticated)/data/curves/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import DashboardSideBar from '../../../../components/DashboardSideBar.svelte';
   export let data: import('./$types').PageData;
 
@@ -10,60 +11,66 @@
   $: curveDate = (data.curveDate ?? '') as string;
   $: note = (data.note ?? '') as string;
 
-  // Chart config
-  const W = 720;
-  const H = 380;
-  const pad = { top: 35, right: 30, bottom: 55, left: 55 };
-  const plotW = W - pad.left - pad.right;
-  const plotH = H - pad.top - pad.bottom;
+  let chartEl: HTMLDivElement;
 
-  // Use par curve years for X-axis (all 3 curves align on years)
-  $: xPoints = par.map(p => p.years);
-  $: xMin = Math.min(...xPoints, 0.5);
-  $: xMax = Math.max(...xPoints, 30);
-  $: xRange = xMax - xMin;
-
-  // Y-axis: find global min/max across all curves
-  $: allYields = [...par.map(p => p.yield), ...spot.map(p => p.yield), ...forward.map(p => p.yield)];
-  $: yMin = Math.floor(Math.min(...allYields) * 2) / 2;  // round down to 0.5
-  $: yMax = Math.ceil(Math.max(...allYields) * 2) / 2 + 0.5;  // round up + headroom
-  $: yRange = yMax - yMin;
-
-  function xScale(years: number): number {
-    return pad.left + ((years - xMin) / xRange) * plotW;
-  }
-  function yScale(y: number): number {
-    return pad.top + plotH - ((y - yMin) / yRange) * plotH;
-  }
-
-  function toPolyline(points: CurvePoint[]): string {
-    return points.map(p => `${xScale(p.years)},${yScale(p.yield)}`).join(' ');
-  }
-
-  $: parLine = toPolyline(par);
-  $: spotLine = toPolyline(spot);
-  $: forwardLine = toPolyline(forward);
-
-  // Y ticks at 0.5% intervals
-  $: yTicks = (() => {
-    const ticks = [];
-    for (let t = yMin; t <= yMax; t += 0.5) ticks.push(Math.round(t * 100) / 100);
-    return ticks;
-  })();
-
-  // X labels from par tenors
-  $: xLabels = par.map(p => ({ years: p.years, label: p.tenor }));
-
-  // Hover: find nearest X position across all tenors
-  let hoveredYears: number | null = null;
-
-  function findAt(curve: CurvePoint[], years: number): CurvePoint | undefined {
-    return curve.find(p => Math.abs(p.years - years) < 0.01);
-  }
-
-  $: hoveredPar = hoveredYears !== null ? findAt(par, hoveredYears) : null;
-  $: hoveredSpot = hoveredYears !== null ? findAt(spot, hoveredYears) : null;
-  $: hoveredFwd = hoveredYears !== null ? findAt(forward, hoveredYears) : null;
+  onMount(async () => {
+    if (!chartEl || par.length === 0) return;
+    const Plotly: any = (await import('plotly.js-dist') as any).default ?? (await import('plotly.js-dist'));
+    const traces = [
+      {
+        x: par.map((p) => p.years),
+        y: par.map((p) => p.yield),
+        mode: 'lines+markers',
+        line: { color: '#60a5fa', width: 2.5 },
+        marker: { color: '#60a5fa', size: 6 },
+        hovertemplate: '%{customdata}<br>Par: %{y:.3f}%<extra></extra>',
+        customdata: par.map((p) => p.tenor),
+        name: 'Par',
+      },
+      {
+        x: spot.map((p) => p.years),
+        y: spot.map((p) => p.yield),
+        mode: 'lines+markers',
+        line: { color: '#7cd2ba', width: 2.5, dash: 'dash' },
+        marker: { color: '#7cd2ba', size: 6 },
+        hovertemplate: 'Spot: %{y:.3f}%<extra></extra>',
+        name: 'Spot',
+      },
+      {
+        x: forward.map((p) => p.years),
+        y: forward.map((p) => p.yield),
+        mode: 'lines+markers',
+        line: { color: '#f59e0b', width: 2.5, dash: 'dot' },
+        marker: { color: '#f59e0b', size: 6 },
+        hovertemplate: 'Fwd: %{y:.3f}%<extra></extra>',
+        name: 'Forward',
+      },
+    ];
+    const layout = {
+      paper_bgcolor: '#0c3a46',
+      plot_bgcolor: '#0c3a46',
+      font: { color: '#a0adb7', size: 11 },
+      margin: { t: 40, r: 30, b: 50, l: 60 },
+      hovermode: 'x unified',
+      legend: {
+        orientation: 'h',
+        x: 0,
+        y: 1.12,
+        font: { color: '#a0adb7' },
+        bgcolor: 'rgba(0,0,0,0)',
+      },
+      xaxis: {
+        gridcolor: '#164e63',
+        title: { text: 'Tenor (years)', font: { color: '#a0adb7' } },
+      },
+      yaxis: {
+        gridcolor: '#164e63',
+        title: { text: 'Yield (%)', font: { color: '#a0adb7' } },
+        ticksuffix: '%',
+      },
+    };
+    Plotly.newPlot(chartEl, traces, layout, { responsive: true, displayModeBar: false });
+  });
 
   // Build merged table data from par (primary) with spot and forward joined on years
   $: tableData = par.map(p => {
@@ -93,76 +100,7 @@
 
       <!-- Multi-line chart -->
       <div class="chart-box">
-        <svg viewBox="0 0 {W} {H}" class="curves-chart">
-          <!-- Grid -->
-          {#each yTicks as tick}
-            {@const y = yScale(tick)}
-            <line x1={pad.left} y1={y} x2={pad.left + plotW} y2={y} stroke="#164e63" stroke-width="0.5" />
-            <text x={pad.left - 8} y={y + 4} text-anchor="end" fill="#a0adb7" font-size="11">{tick.toFixed(1)}%</text>
-          {/each}
-
-          <!-- X-axis -->
-          <line x1={pad.left} y1={pad.top + plotH} x2={pad.left + plotW} y2={pad.top + plotH} stroke="#164e63" stroke-width="1" />
-          {#each xLabels as xl}
-            <text x={xScale(xl.years)} y={pad.top + plotH + 18} text-anchor="middle" fill="#a0adb7" font-size="11">{xl.label}</text>
-          {/each}
-
-          <!-- Par curve (blue, solid) -->
-          <polyline points={parLine} fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linejoin="round" />
-          <!-- Spot curve (green, dashed) -->
-          <polyline points={spotLine} fill="none" stroke="#7cd2ba" stroke-width="2.5" stroke-dasharray="8,4" stroke-linejoin="round" />
-          <!-- Forward curve (orange, dotted) -->
-          <polyline points={forwardLine} fill="none" stroke="#f59e0b" stroke-width="2.5" stroke-dasharray="3,3" stroke-linejoin="round" />
-
-          <!-- Hover hit zones on par X points -->
-          {#each par as p}
-            <rect
-              x={xScale(p.years) - 15} y={pad.top} width="30" height={plotH}
-              fill="transparent"
-              on:mouseenter={() => hoveredYears = p.years}
-              on:mouseleave={() => hoveredYears = null}
-            />
-          {/each}
-
-          <!-- Hover dots + tooltip -->
-          {#if hoveredYears !== null}
-            {@const hx = xScale(hoveredYears)}
-            <line x1={hx} y1={pad.top} x2={hx} y2={pad.top + plotH} stroke="#ffffff33" stroke-width="1" />
-
-            {#if hoveredPar}
-              <circle cx={hx} cy={yScale(hoveredPar.yield)} r="5" fill="#60a5fa" stroke="white" stroke-width="1.5" />
-            {/if}
-            {#if hoveredSpot}
-              <circle cx={hx} cy={yScale(hoveredSpot.yield)} r="5" fill="#7cd2ba" stroke="white" stroke-width="1.5" />
-            {/if}
-            {#if hoveredFwd}
-              <circle cx={hx} cy={yScale(hoveredFwd.yield)} r="5" fill="#f59e0b" stroke="white" stroke-width="1.5" />
-            {/if}
-
-            <!-- Tooltip box -->
-            {@const tooltipX = hx < W / 2 ? hx + 12 : hx - 132}
-            <rect x={tooltipX} y={pad.top + 4} width="120" height="62" rx="4" fill="#0c3a46ee" stroke="#164e63" />
-            <text x={tooltipX + 8} y={pad.top + 20} fill="#a0adb7" font-size="10" font-weight="bold">
-              {hoveredPar?.tenor ?? hoveredYears + 'Y'}
-            </text>
-            <text x={tooltipX + 8} y={pad.top + 35} fill="#60a5fa" font-size="11">Par: {hoveredPar?.yield.toFixed(3) ?? '—'}%</text>
-            <text x={tooltipX + 8} y={pad.top + 49} fill="#7cd2ba" font-size="11">Spot: {hoveredSpot?.yield.toFixed(3) ?? '—'}%</text>
-            <text x={tooltipX + 8} y={pad.top + 63} fill="#f59e0b" font-size="11">Fwd: {hoveredFwd?.yield.toFixed(3) ?? '—'}%</text>
-          {/if}
-
-          <!-- Legend -->
-          <rect x={pad.left + 10} y={pad.top + 6} width="130" height="50" rx="4" fill="#0c3a46cc" />
-          <line x1={pad.left + 18} y1={pad.top + 20} x2={pad.left + 38} y2={pad.top + 20} stroke="#60a5fa" stroke-width="2.5" />
-          <text x={pad.left + 42} y={pad.top + 24} fill="#60a5fa" font-size="11">Par Curve</text>
-          <line x1={pad.left + 18} y1={pad.top + 34} x2={pad.left + 38} y2={pad.top + 34} stroke="#7cd2ba" stroke-width="2.5" stroke-dasharray="8,4" />
-          <text x={pad.left + 42} y={pad.top + 38} fill="#7cd2ba" font-size="11">Spot Curve</text>
-          <line x1={pad.left + 18} y1={pad.top + 48} x2={pad.left + 38} y2={pad.top + 48} stroke="#f59e0b" stroke-width="2.5" stroke-dasharray="3,3" />
-          <text x={pad.left + 42} y={pad.top + 52} fill="#f59e0b" font-size="11">Forward Curve</text>
-
-          <!-- Y-axis label -->
-          <text x={14} y={pad.top + plotH / 2} text-anchor="middle" fill="#a0adb7" font-size="12"
-                transform="rotate(-90 14 {pad.top + plotH / 2})">Yield (%)</text>
-        </svg>
+        <div bind:this={chartEl} class="curves-chart" />
       </div>
 
       <!-- Data table -->
@@ -179,12 +117,7 @@
           </thead>
           <tbody>
             {#each tableData as row}
-              <tr
-                class="table-row border-b border-slate-400"
-                class:highlight-row={hoveredYears === row.years}
-                on:mouseenter={() => hoveredYears = row.years}
-                on:mouseleave={() => hoveredYears = null}
-              >
+              <tr class="table-row border-b border-slate-400">
                 <td class="table-cell px-4 py-2"><strong>{row.tenor}</strong></td>
                 <td class="table-cell px-4 py-2 par-col">{row.parYield.toFixed(3)}</td>
                 <td class="table-cell px-4 py-2 spot-col">{row.spotRate?.toFixed(3) ?? '—'}</td>
@@ -226,10 +159,7 @@
 
   .curves-chart {
     width: 100%;
-    max-width: 720px;
-    height: auto;
-
-    rect[fill="transparent"] { cursor: crosshair; }
+    min-height: 400px;
   }
 
   .table-wrapper {
@@ -239,6 +169,4 @@
   .par-col { color: #60a5fa; font-weight: 600; font-variant-numeric: tabular-nums; }
   .spot-col { color: #7cd2ba; font-weight: 600; font-variant-numeric: tabular-nums; }
   .fwd-col { color: #f59e0b; font-weight: 600; font-variant-numeric: tabular-nums; }
-
-  .highlight-row { background-color: $bgc-color !important; }
 </style>

--- a/src/routes/(authenticated)/data/treasury_curve/+page.svelte
+++ b/src/routes/(authenticated)/data/treasury_curve/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import DashboardSideBar from '../../../../components/DashboardSideBar.svelte';
 
   export let data: { curveData: Array<{
@@ -23,25 +24,38 @@
     }
   }
 
-  // SVG chart dimensions
-  const chartWidth = 700;
-  const chartHeight = 320;
-  const pad = { top: 30, right: 30, bottom: 50, left: 55 };
-  const plotW = chartWidth - pad.left - pad.right;
-  const plotH = chartHeight - pad.top - pad.bottom;
+  let chartEl: HTMLDivElement;
 
-  $: yMin = 0;
-  $: yMax = Math.ceil(Math.max(...curveData.map(d => d.couponRate), 5) + 0.5);
-  $: yRange = yMax - yMin;
-
-  $: points = curveData.map((d, i) => ({
-    ...d,
-    x: pad.left + (i / Math.max(curveData.length - 1, 1)) * plotW,
-    y: pad.top + plotH - ((d.couponRate - yMin) / yRange) * plotH,
-  }));
-
-  $: polyline = points.map(p => `${p.x},${p.y}`).join(' ');
-  $: yTicks = Array.from({ length: yMax - yMin + 1 }, (_, i) => yMin + i);
+  onMount(async () => {
+    if (!chartEl || curveData.length === 0) return;
+    const Plotly: any = (await import('plotly.js-dist') as any).default ?? (await import('plotly.js-dist'));
+    const trace = {
+      x: curveData.map((d) => d.tenor),
+      y: curveData.map((d) => d.couponRate),
+      mode: 'lines+markers',
+      line: { color: '#7cd2ba', width: 2.5, shape: 'linear' },
+      marker: { color: '#7cd2ba', size: 8 },
+      hovertemplate: '%{x}: %{y:.3f}%<extra></extra>',
+      name: 'On-the-run',
+    };
+    const layout = {
+      paper_bgcolor: '#0c3a46',
+      plot_bgcolor: '#0c3a46',
+      font: { color: '#a0adb7', size: 11 },
+      margin: { t: 30, r: 30, b: 50, l: 60 },
+      xaxis: {
+        type: 'category',
+        gridcolor: '#164e63',
+        title: { text: 'Tenor', font: { color: '#a0adb7' } },
+      },
+      yaxis: {
+        gridcolor: '#164e63',
+        title: { text: 'Yield (%)', font: { color: '#a0adb7' } },
+        ticksuffix: '%',
+      },
+    };
+    Plotly.newPlot(chartEl, [trace], layout, { responsive: true, displayModeBar: false });
+  });
 
   let hoveredIndex: number | null = null;
 </script>
@@ -105,54 +119,7 @@
   <!-- Yield Curve Chart -->
   <div class="chart-box">
     <h2 class="chart-title">Yield Curve</h2>
-    <svg viewBox="0 0 {chartWidth} {chartHeight}" class="curve-chart">
-      <!-- Grid lines -->
-      {#each yTicks as tick}
-        {@const y = pad.top + plotH - ((tick - yMin) / yRange) * plotH}
-        <line x1={pad.left} y1={y} x2={pad.left + plotW} y2={y} stroke="#164e63" stroke-width="1" />
-        <text x={pad.left - 8} y={y + 4} text-anchor="end" fill="#a0adb7" font-size="11">{tick}%</text>
-      {/each}
-
-      <!-- X-axis -->
-      <line x1={pad.left} y1={pad.top + plotH} x2={pad.left + plotW} y2={pad.top + plotH} stroke="#164e63" stroke-width="1" />
-
-      <!-- X-axis labels -->
-      {#each points as p}
-        <text x={p.x} y={pad.top + plotH + 20} text-anchor="middle" fill="#a0adb7" font-size="11">
-          {p.tenor}
-        </text>
-      {/each}
-
-      <!-- Line -->
-      {#if points.length > 1}
-        <polyline points={polyline} fill="none" stroke="#7cd2ba" stroke-width="2.5" stroke-linejoin="round" />
-      {/if}
-
-      <!-- Data dots -->
-      {#each points as p, i}
-        <circle
-          cx={p.x} cy={p.y} r={hoveredIndex === i ? 6 : 4}
-          fill={hoveredIndex === i ? '#7cd2ba' : '#0c3a46'}
-          stroke="#7cd2ba" stroke-width="2"
-          on:mouseenter={() => hoveredIndex = i}
-          on:mouseleave={() => hoveredIndex = null}
-          role="img" aria-label="{p.tenor}: {p.couponRate.toFixed(2)}%"
-        />
-        {#if hoveredIndex === i}
-          <rect x={p.x - 36} y={p.y - 30} width="72" height="22" rx="4"
-                fill="#0c3a46" stroke="#7cd2ba" stroke-width="1" />
-          <text x={p.x} y={p.y - 15} text-anchor="middle" fill="#7cd2ba" font-size="12" font-weight="bold">
-            {p.couponRate.toFixed(2)}%
-          </text>
-        {/if}
-      {/each}
-
-      <!-- Y-axis label -->
-      <text x={14} y={pad.top + plotH / 2} text-anchor="middle" fill="#a0adb7" font-size="12"
-            transform="rotate(-90 14 {pad.top + plotH / 2})">
-        Yield (%)
-      </text>
-    </svg>
+    <div bind:this={chartEl} class="curve-chart" />
   </div>
     </div>
   </div>
@@ -264,9 +231,6 @@
 
   .curve-chart {
     width: 100%;
-    max-width: 700px;
-    height: auto;
-
-    circle { cursor: pointer; transition: r 0.1s; }
+    min-height: 360px;
   }
 </style>


### PR DESCRIPTION
Closes #198. Mirrors the pattern from PR #113 across the remaining three hand-rolled SVG chart pages.

## Changes

**`/data/cpi_index`** — single-line time series. Adds range selector (1Y/5Y/10Y/25Y/All) + range slider. Y-axis label adapts to selected series.

**`/data/treasury_curve`** — single-line yield curve, tenor on category-axis. Hover shows tenor + yield with % suffix.

**`/data/curves`** — three traces (par solid blue, spot dashed teal, forward dotted amber) with horizontal legend + unified hover.

In all cases:
- Chart fills page width.
- Dark theme matched (`#0c3a46` bg).
- Tables below chart unchanged.
- `hoveredIndex` cross-highlight (table-row → chart-point) removed; plotly handles its own hover.

## Verification

- All 4 chart pages: HTTP 200, plotly container present, no hand-rolled SVG remnant.
- `npx svelte-check`: 173/210 — baseline-equivalent.
- `npx vitest run` for prices: 47 passed.

After this PR, every chart that ui-service owns is on plotly.js-dist (`GraphSection.svelte` and `treasuries2` already were).

🤖 Generated with [Claude Code](https://claude.com/claude-code)