### PR TITLE
bugfix: bond RunValuation now requests + maps PRESENT_VALUE measure (#209)

### DIFF
--- a/src/lib/valuation.ts
+++ b/src/lib/valuation.ts
@@ -48,6 +48,7 @@ export interface CashflowEntry {
 }
 
 export interface ValuationResult {
+  presentValue?: string;
   dirtyPrice?: string;
   accruedInterest?: string;
   currentYield?: string;
@@ -120,6 +121,7 @@ const MEASURE_DISCOUNT_MARGIN = MeasureProto.DISCOUNT_MARGIN;
 const MEASURE_SPREAD_DURATION = MeasureProto.SPREAD_DURATION;
 
 const VALUATION_MEASURES = [
+  MEASURE_PRESENT_VALUE,
   MeasureProto.DIRTY_PRICE,
   MeasureProto.ACCRUED_INTEREST,
   MeasureProto.CURRENT_YIELD,
@@ -291,6 +293,7 @@ export async function RunValuation(inputs: BondCalculatorInputs, apiKey?: string
     response.getMeasureResultsList().forEach(entry => {
       const value = entry.getMeasureDecimalValue()?.getArbitraryPrecisionValue();
       switch (entry.getMeasure()) {
+        case MEASURE_PRESENT_VALUE:            result.presentValue = value; break;
         case MeasureProto.DIRTY_PRICE:         result.dirtyPrice = value; break;
         case MeasureProto.ACCRUED_INTEREST:    result.accruedInterest = value; break;
         case MeasureProto.CURRENT_YIELD:       result.currentYield = value; break;

--- a/src/tests/bond-present-value-measure.test.ts
+++ b/src/tests/bond-present-value-measure.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #209 regression test — bond RunValuation must request and map the
+ * PRESENT_VALUE measure.
+ *
+ * Tight-scoped guard: any future PR that drops PRESENT_VALUE from the bond
+ * measure list or removes the switch-case mapping will fail here directly,
+ * rather than via downstream invariant assertions in
+ * bond-pricing-consistency.test.ts that were dependent on this for their
+ * pre-fix failures.
+ */
+import { describe, expect, test, vi } from 'vitest';
+
+const capturedRequests: any[] = [];
+
+vi.mock('@fintekkers/ledger-models/node/fintekkers/services/valuation-service/valuation_service_grpc_pb.js', () => ({
+  ValuationClient: vi.fn().mockImplementation(() => ({
+    runValuation: vi.fn().mockImplementation((request: any, callback: Function) => {
+      capturedRequests.push(request);
+      // Return a stub response that includes a PRESENT_VALUE measure result —
+      // proves the switch-case in RunValuation maps it onto result.presentValue.
+      callback(null, {
+        getMeasureResultsList: () => [
+          {
+            getMeasure: () => 9, // MeasureProto.PRESENT_VALUE
+            getMeasureDecimalValue: () => ({ getArbitraryPrecisionValue: () => '99.875' }),
+          },
+        ],
+        getCashflowsList: () => [],
+      });
+    }),
+  })),
+}));
+
+vi.mock('$lib/grpc-auth', () => ({
+  getServiceConnection: vi.fn().mockReturnValue({ url: 'localhost:80', credentials: {} }),
+}));
+
+import { RunValuation } from '$lib/valuation';
+import type { BondCalculatorInputs } from '$lib/valuation';
+
+const MANUAL_BOND: BondCalculatorInputs = {
+  mode: 'manual',
+  price: '99.875',
+  faceValue: '100',
+  couponRate: '5',
+  couponFrequency: 'SEMIANNUALLY',
+  maturityDate: '2030-01-15',
+};
+
+describe('Bond PRESENT_VALUE measure (#209)', () => {
+  test('RunValuation includes PRESENT_VALUE in the requested measure list', async () => {
+    capturedRequests.length = 0;
+    await RunValuation(MANUAL_BOND);
+    expect(capturedRequests.length).toBe(1);
+    const measures = capturedRequests[0].getMeasuresList();
+    // MeasureProto.PRESENT_VALUE is enum value 9.
+    expect(measures).toContain(9);
+  });
+
+  test('RunValuation maps a PRESENT_VALUE response to result.presentValue', async () => {
+    const result = await RunValuation(MANUAL_BOND);
+    expect(result.error).toBeUndefined();
+    expect(result.presentValue).toBe('99.875');
+  });
+});


### PR DESCRIPTION
Closes FinTekkers/second-brain#209.

## Summary

Bond `RunValuation` in `src/lib/valuation.ts` was not requesting the `PRESENT_VALUE` measure (missing from `VALUATION_MEASURES`) and not mapping it on the response (no switch-case). Result: `result.presentValue` was always `undefined` for bonds — the root cause of the 13 bond-pricing-consistency failures called out in PR #116.

Three-line fix:

1. Add `MEASURE_PRESENT_VALUE` to `VALUATION_MEASURES` (line 122).
2. Add `case MEASURE_PRESENT_VALUE: result.presentValue = value; break;` to the switch (lines 290-302).
3. Declare `presentValue?: string` on the `ValuationResult` interface — it was missing entirely. The bond switch was silently writing to an undeclared property; only the sibling `TipsValuationResult` and `FrnValuationResult` interfaces had `presentValue` declared.

Item (3) is the bonus catch — adding it collapsed 18 svelte-check errors at downstream callsites that read `result.presentValue` on a bond result.

## Verification

| Suite | Before | After |
|---|---|---|
| `bond-pricing-consistency.test.ts` | 13 fail / 14 pass | **27 / 27** |
| `cashflow-schedule.test.ts` ("Sum of cashflow PVs matches main presentValue") | fail | pass |
| `bond-present-value-measure.test.ts` (NEW regression) | — | 2 / 2 |
| `TipsValuation` / `tips-calculator-e2e` | unchanged | unchanged |
| `frn-pricing-consistency` | 6 pre-existing failures | 6 pre-existing failures (off-by-one in mock helper, separate issue) |
| `npx svelte-check` | 174 errors / 210 warnings | **156 / 210** (-18 errors) |

## New regression test

`src/tests/bond-present-value-measure.test.ts` — two tight cases that fail directly if anyone drops PRESENT_VALUE from the measure list or removes the switch-case mapping. Failure mode is then clear at the source rather than via downstream invariant assertions.

## Notes for reviewers

- The PR is independent of the engine-path migration (#182 / PR #116). It applies cleanly to main as it stands today; if #116 merges first, this branch will need a trivial conflict resolution on the same line of the measure list.
- Pre-existing FRN failures (6) are unrelated and tracked separately — they're cashflow-period-count off-by-ones in `valuationMockHelper.ts`, not in calculator code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)