### PR TITLE
valuation: migrate RunTipsValuation to ProductInput.Tips engine path (#207)

### DIFF
--- a/src/lib/valuation.ts
+++ b/src/lib/valuation.ts
@@ -1,7 +1,7 @@
 import { ValuationClient } from '@fintekkers/ledger-models/node/fintekkers/services/valuation-service/valuation_service_grpc_pb.js';
 import { SecurityClient } from '@fintekkers/ledger-models/node/fintekkers/services/security-service/security_service_grpc_pb.js';
 import { ValuationRequestProto } from '@fintekkers/ledger-models/node/fintekkers/requests/valuation/valuation_request_pb.js';
-import { ProductInput, BondInput } from '@fintekkers/ledger-models/node/fintekkers/requests/valuation/product_inputs_pb.js';
+import { ProductInput, BondInput, TipsInput } from '@fintekkers/ledger-models/node/fintekkers/requests/valuation/product_inputs_pb.js';
 import { QuerySecurityRequestProto } from '@fintekkers/ledger-models/node/fintekkers/requests/security/query_security_request_pb.js';
 import { PriceProto } from '@fintekkers/ledger-models/node/fintekkers/models/price/price_pb.js';
 import { SecurityProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/security_pb.js';
@@ -403,18 +403,22 @@ export async function RunTipsValuation(inputs: TipsCalculatorInputs, apiKey?: st
       ? await buildSecurityProtoFromCusip(inputs.cusip!, apiKey)
       : buildManualTipsSecurityProto(inputs);
 
-    const priceProto = buildPriceProto(securityProto, inputs.price);
-    const cpiPriceProto = buildCpiPriceProto(inputs.currentCpi);
+    // Engine path (#183 / #207): typed TipsInput inside ProductInput, instead
+    // of the legacy security_input + price_input + cpi_price_input flat fields.
+    // The valuation service routes TIPS requests through engine/tips.rs when
+    // product_input.tips is set.
+    const tipsInput = new TipsInput()
+      .setSecurity(securityProto)
+      .setCleanPrice(decimalValue(inputs.price))
+      .setCurrentCpi(decimalValue(inputs.currentCpi));
+    const productInput = new ProductInput().setTips(tipsInput);
 
     const request = new ValuationRequestProto();
     request.setObjectClass('ValuationRequestProto');
     request.setVersion('0.0.1');
     request.setOperationType(RequestOperationTypeProto.GET);
     request.setAsofDatetime(ZonedDateTime.now().toProto());
-    request.setSecurityInput(securityProto);
-    request.setPriceInput(priceProto);
-
-    request.setCpiPriceInput(cpiPriceProto);
+    request.setProductInput(productInput);
 
     TIPS_VALUATION_MEASURES.forEach(m => request.addMeasures(m));
 

--- a/src/tests/tips-engine-path-request-shape.test.ts
+++ b/src/tests/tips-engine-path-request-shape.test.ts
@@ -1,0 +1,79 @@
+/**
+ * ISSUE #207 — regression test for the TIPS engine-path request shape.
+ *
+ * Asserts that RunTipsValuation builds a ValuationRequestProto with
+ * product_input.tips set (carrying security + clean_price + current_cpi)
+ * and the legacy flat fields NOT set. Mirrors the bond engine-path
+ * regression test introduced for #182.
+ */
+import { describe, expect, test, vi } from 'vitest';
+
+const capturedRequests: any[] = [];
+
+vi.mock('@fintekkers/ledger-models/node/fintekkers/services/valuation-service/valuation_service_grpc_pb.js', () => ({
+  ValuationClient: vi.fn().mockImplementation(() => ({
+    runValuation: vi.fn().mockImplementation((request: any, callback: Function) => {
+      capturedRequests.push(request);
+      callback(null, {
+        getMeasureResultsList: () => [],
+        getCashflowsList: () => [],
+      });
+    }),
+  })),
+}));
+
+vi.mock('$lib/grpc-auth', () => ({
+  getServiceConnection: vi.fn().mockReturnValue({ url: 'localhost:80', credentials: {} }),
+}));
+
+import { RunTipsValuation } from '$lib/valuation';
+import type { TipsCalculatorInputs } from '$lib/valuation';
+
+const MANUAL_TIPS: TipsCalculatorInputs = {
+  mode: 'manual',
+  price: '98.5',
+  currentCpi: '314.175',
+  settlementDate: '2026-03-19',
+  faceValue: '1000',
+  realCouponRate: '0.625',
+  couponFrequency: 'SEMIANNUALLY',
+  referenceCpi: '256.394',
+  maturityDate: '2030-01-15',
+};
+
+describe('TIPS engine-path request shape (#207)', () => {
+  test('RunTipsValuation sets product_input.tips, not security_input / price_input / cpi_price_input', async () => {
+    capturedRequests.length = 0;
+    await RunTipsValuation(MANUAL_TIPS);
+    expect(capturedRequests.length).toBe(1);
+    const req = capturedRequests[0];
+
+    // Engine path is set: product_input.tips carries security + clean_price + current_cpi.
+    expect(req.hasProductInput()).toBe(true);
+    const tipsInput = req.getProductInput()?.getTips();
+    expect(tipsInput).toBeDefined();
+    expect(tipsInput.getSecurity()).toBeDefined();
+    expect(tipsInput.getCleanPrice()).toBeDefined();
+    expect(tipsInput.getCleanPrice().getArbitraryPrecisionValue()).toBe('98.5');
+    expect(tipsInput.getCurrentCpi()).toBeDefined();
+    expect(tipsInput.getCurrentCpi().getArbitraryPrecisionValue()).toBe('314.175');
+
+    // Legacy flat fields are NOT set on TIPS requests.
+    expect(req.hasSecurityInput()).toBe(false);
+    expect(req.hasPriceInput()).toBe(false);
+    expect(req.hasCpiPriceInput()).toBe(false);
+
+    // BOND oneof case is NOT chosen.
+    expect(req.getProductInput()?.getBond()).toBeUndefined();
+  });
+
+  test('RunTipsValuation still preserves the standard request envelope', async () => {
+    capturedRequests.length = 0;
+    await RunTipsValuation(MANUAL_TIPS);
+    const req = capturedRequests[0];
+
+    expect(req.hasAsofDatetime()).toBe(true);
+    expect(req.getMeasuresList().length).toBeGreaterThan(0);
+    expect(req.getOperationType()).toBeGreaterThan(0);
+  });
+});

--- a/src/tests/valuationMockHelper.ts
+++ b/src/tests/valuationMockHelper.ts
@@ -128,13 +128,21 @@ export function createValuationClientMock() {
 	return vi.fn().mockImplementation(() => ({
 		runValuation: vi.fn().mockImplementation((request: any, callback: Function) => {
 			try {
-				// Bond requests now use the engine path: product_input.bond carries
-				// security + clean_price (#182). TIPS / FRN still use the legacy
-				// flat security_input + price_input. Fall back so the mock works
-				// for both shapes.
+				// Three input shapes live in this codebase:
+				//   - Engine path bond (#182): product_input.bond → BondInput
+				//   - Engine path TIPS (#207): product_input.tips → TipsInput
+				//   - Legacy flat fields (FRN today, bond/TIPS pre-migration):
+				//       security_input + price_input (+ cpi_price_input for TIPS)
+				// Read security + price + cpi from whichever shape is set so the
+				// mock works against all current and post-migration callers.
 				const bondInput = request.getProductInput?.()?.getBond?.();
-				const sec = bondInput?.getSecurity?.() ?? request.getSecurityInput?.();
-				const priceProto = bondInput?.getCleanPrice?.() ?? request.getPriceInput?.()?.getPrice?.();
+				const tipsInput = request.getProductInput?.()?.getTips?.();
+				const sec = bondInput?.getSecurity?.()
+					?? tipsInput?.getSecurity?.()
+					?? request.getSecurityInput?.();
+				const priceProto = bondInput?.getCleanPrice?.()
+					?? tipsInput?.getCleanPrice?.()
+					?? request.getPriceInput?.()?.getPrice?.();
 				const priceStr = priceProto?.getArbitraryPrecisionValue?.() ?? '100';
 				const price = parseFloat(priceStr);
 
@@ -151,9 +159,13 @@ export function createValuationClientMock() {
 					const referenceCpi = parseFloat(
 						sec?.getBaseCpi?.()?.getArbitraryPrecisionValue?.() ?? '256.394'
 					);
-					const currentCpi = parseFloat(
-						request.getCpiPriceInput?.()?.getPrice?.()?.getArbitraryPrecisionValue?.() ?? '314.175'
-					);
+					// Engine-path TIPS carries current_cpi on the TipsInput; legacy
+					// path used a separate cpi_price_input PriceProto. Read from
+					// whichever is set.
+					const currentCpiStr = tipsInput?.getCurrentCpi?.()?.getArbitraryPrecisionValue?.()
+						?? request.getCpiPriceInput?.()?.getPrice?.()?.getArbitraryPrecisionValue?.()
+						?? '314.175';
+					const currentCpi = parseFloat(currentCpiStr);
 					const indexRatio = referenceCpi > 0 ? currentCpi / referenceCpi : 1;
 					const adjustedPrincipal = faceValue * indexRatio;
 					const adjustedCouponPeriodic = adjustedPrincipal * couponRate / 2;


### PR DESCRIPTION
Closes FinTekkers/second-brain#207. Mirrors PR #116's bond migration for TIPS.

## Summary

`RunTipsValuation` in `src/lib/valuation.ts` now constructs requests via the engine path (`product_input.tips` = `TipsInput{security, clean_price, current_cpi}`) introduced in #183 and shipped in ledger-models v0.1.132. Legacy `security_input` + `price_input` + `cpi_price_input` flat fields are no longer set on TIPS requests.

`RunValuation` (already migrated in PR #116) is unchanged. `RunFrnValuation` stays on the legacy path until #208.

## Changes

- `src/lib/valuation.ts` — swap `setSecurityInput / setPriceInput / setCpiPriceInput` for `setProductInput(ProductInput().setTips(...))`. Three-line construction:
  ```ts
  const tipsInput = new TipsInput()
    .setSecurity(securityProto)
    .setCleanPrice(decimalValue(inputs.price))
    .setCurrentCpi(decimalValue(inputs.currentCpi));
  request.setProductInput(new ProductInput().setTips(tipsInput));
  ```
  `buildPriceProto` + `buildCpiPriceProto` stay — `RunFrnValuation` still calls them until #208.

- `src/tests/valuationMockHelper.ts` — read security + price + current_cpi from `product_input.tips` first; fall back to legacy flat fields. Mock now handles bond engine + TIPS engine + legacy FRN.

- `src/tests/tips-engine-path-request-shape.test.ts` — new tight regression test (2 cases) asserting `product_input.tips` is set with security + clean_price + current_cpi, and legacy fields are not.

## Verification

| Suite | Result |
|---|---|
| TipsValuation | green |
| tips-calculator-e2e | green |
| bond-pricing-consistency (#117 + #182 baselines) | 27/27 green |
| cashflow-schedule | green |
| bond-engine-path-request-shape (#182) | green |
| bond-present-value-measure (#117/#209) | green |
| **tips-engine-path-request-shape** (NEW) | **2/2** |
| `npx svelte-check` | 163/210 — baseline-equivalent |

## Notes for reviewers

- Caller blast radius is one function. Acceptance criterion "existing TIPS tests pass without modification" met after the mock-helper update — same pattern PR #116 used for bond.
- `buildPriceProto` / `buildCpiPriceProto` retained intentionally — they're still consumed by `RunFrnValuation`. They get cleaned up as part of #208 + #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)