### PR TITLE
positions: TRANSACTION view + tradeDate filter + portfolio-scope resubmit

### DIFF
--- a/src/components/widgets/PortfolioGrid.svelte
+++ b/src/components/widgets/PortfolioGrid.svelte
@@ -26,12 +26,28 @@
 		// and a single unsupported measure 500s the whole positions page.
 		// Backend gap tracked in second-brain#219; restore the bond analytics
 		// columns here once that issue is closed.
+		//
+		// View defaults:
+		//   - positionType=TRANSACTION rolls up positions at the transaction
+		//     level (current state), not per tax lot — what a portfolio
+		//     manager wants on first load.
+		//   - tradeDate < today filters out unsettled/future-dated trades so
+		//     the page reflects the as-of-now position.
+		//   - hideZeros suppresses positions whose every measure is zero.
+		//   - portfolioId scopes the search to the clicked portfolio (SOMA in
+		//     the seeded dataset). The /data/positions page-server already
+		//     wires this through to FetchPosition's PORTFOLIO_ID filter — no
+		//     extension required.
+		const today = new Date().toISOString().slice(0, 10);
 		const params = new URLSearchParams({
 			portfolioId,
 			fields: 'SECURITY_DESCRIPTION,PORTFOLIO_NAME',
 			measures: 'DIRECTED_QUANTITY,MARKET_VALUE,PROFIT_LOSS,CURRENT_YIELD,YIELD_TO_MATURITY',
 			positionView: 'DEFAULT_VIEW',
-			positionType: 'TAX_LOT',
+			positionType: 'TRANSACTION',
+			tradeDate: today,
+			tradeDateOperator: 'lesser_than',
+			hideZeros: 'true',
 		});
 		return `/data/positions?${params.toString()}`;
 	}

--- a/src/components/widgets/PositionSelect.svelte
+++ b/src/components/widgets/PositionSelect.svelte
@@ -85,6 +85,17 @@
       url += `&hideZeros=true`;
     }
 
+    // Preserve portfolioId from the inbound URL so re-running the form keeps
+    // the search scoped to the portfolio the user navigated in from. Without
+    // this, clicking SOMA → /positions → "Run" would silently widen the
+    // query to all portfolios. Tracked in second-brain#220.
+    if (typeof window !== "undefined") {
+      const inboundPortfolioId = new URLSearchParams(window.location.search).get("portfolioId");
+      if (inboundPortfolioId) {
+        url += `&portfolioId=${encodeURIComponent(inboundPortfolioId)}`;
+      }
+    }
+
     window.location.href = url;
   }
 

--- a/src/tests/PortfolioGrid.test.ts
+++ b/src/tests/PortfolioGrid.test.ts
@@ -47,14 +47,22 @@ describe('PortfolioGrid', () => {
 
 	test('each row contains links with the correct positions URL', () => {
 		const links = screen.getAllByRole('link');
+		// Date computed the same way as PortfolioGrid.getPositionsUrl. The
+		// component runs in the same test invocation so they will agree
+		// barring a midnight rollover mid-test (which would also flake the
+		// component's own behavior, not our assertion shape).
+		const today = new Date().toISOString().slice(0, 10);
 
 		for (const row of mockRows) {
 			const expectedParams = new URLSearchParams({
 				portfolioId: row.portfolioId,
 				fields: 'SECURITY_DESCRIPTION,PORTFOLIO_NAME',
-				measures: 'DIRECTED_QUANTITY,MARKET_VALUE,ACCRUED_INTEREST,DIRTY_PRICE,CLEAN_PRICE,CONVEXITY,MODIFIED_DURATION,DV01,YIELD_TO_MATURITY',
+				measures: 'DIRECTED_QUANTITY,MARKET_VALUE,PROFIT_LOSS,CURRENT_YIELD,YIELD_TO_MATURITY',
 				positionView: 'DEFAULT_VIEW',
-				positionType: 'TAX_LOT',
+				positionType: 'TRANSACTION',
+				tradeDate: today,
+				tradeDateOperator: 'lesser_than',
+				hideZeros: 'true',
 			});
 			const expectedUrl = `/data/positions?${expectedParams.toString()}`;
 
@@ -80,9 +88,12 @@ describe('PortfolioGrid', () => {
 
 		expect(params.get('portfolioId')).toBe('portfolio-001');
 		expect(params.get('fields')).toBe('SECURITY_DESCRIPTION,PORTFOLIO_NAME');
-		expect(params.get('measures')).toBe('DIRECTED_QUANTITY,MARKET_VALUE,ACCRUED_INTEREST,DIRTY_PRICE,CLEAN_PRICE,CONVEXITY,MODIFIED_DURATION,DV01,YIELD_TO_MATURITY');
+		expect(params.get('measures')).toBe('DIRECTED_QUANTITY,MARKET_VALUE,PROFIT_LOSS,CURRENT_YIELD,YIELD_TO_MATURITY');
 		expect(params.get('positionView')).toBe('DEFAULT_VIEW');
-		expect(params.get('positionType')).toBe('TAX_LOT');
+		expect(params.get('positionType')).toBe('TRANSACTION');
+		expect(params.get('tradeDate')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(params.get('tradeDateOperator')).toBe('lesser_than');
+		expect(params.get('hideZeros')).toBe('true');
 	});
 
 	test('clicking a column header triggers sorting', async () => {

--- a/src/tests/e2e/portfolio-soma-positions.spec.ts
+++ b/src/tests/e2e/portfolio-soma-positions.spec.ts
@@ -5,28 +5,29 @@
  *   1. /data/portfolios renders the seeded "Federal Reserve SOMA Holdings" row.
  *   2. Clicking the portfolio name link navigates to /data/positions with the
  *      portfolio's UUID as `portfolioId` in the query string.
- *   3. The positions page renders the default flat tax-lot view for SOMA.
+ *   3. The positions page renders the default TRANSACTION view scoped to SOMA.
  *   4. Switching the request to fields=PRODUCT_TYPE & measures=DIRECTED_QUANTITY
  *      (the backend's group-by mode) renders one row per product type with the
  *      aggregated DIRECTED_QUANTITY value — i.e. the page surfaces a real
  *      Measure × Field aggregation by relying on the position-service's
- *      server-side aggregation when only one field is requested.
+ *      server-side aggregation when only one field is requested. The query is
+ *      portfolio-scoped via the PORTFOLIO_ID PositionFilter wired through
+ *      +page.server.ts → FetchPosition.
  *
- * Why URL-driven for step 4 (instead of driving the PositionSelect controls):
- *   PositionSelect.fetchPositions() drops the inbound `portfolioId` query param
- *   when constructing the next URL — second-brain#220. Until that is fixed,
- *   the only way to keep the request portfolio-scoped through a UI flow is to
- *   URL-navigate. Filed as an issue rather than fixed inline because the
- *   workaround is clean and the fix needs careful thought (which params to
- *   preserve generically).
+ * Default-URL filter set (mirrored both in PortfolioGrid.getPositionsUrl and
+ * step 4 of this test):
+ *   - positionType=TRANSACTION (transaction-rolled-up state, not per tax lot).
+ *   - tradeDate=<today> & tradeDateOperator=lesser_than excludes future-dated
+ *     / unsettled trades so the page reflects the as-of-now position.
+ *   - hideZeros=true suppresses fully-zero rows.
+ *   - portfolioId scopes the search to the clicked portfolio.
  *
- * Why the PortfolioGrid default URL was trimmed in this PR:
- *   The previous default included ACCRUED_INTEREST/DIRTY_PRICE/CLEAN_PRICE/
- *   CONVEXITY/MODIFIED_DURATION — all of which the ledger-service
- *   position-search returns `12 UNIMPLEMENTED` for. A single unsupported
- *   measure 500s the entire stream, so every portfolio click landed on the
- *   error page. Trimmed to working measures only; backend gap tracked in
- *   second-brain#219.
+ * Why the PortfolioGrid default URL was trimmed earlier in this branch's
+ * history: the previous default included ACCRUED_INTEREST / DIRTY_PRICE /
+ * CLEAN_PRICE / CONVEXITY / MODIFIED_DURATION — all of which the ledger-
+ * service position-search returns `12 UNIMPLEMENTED` for. A single
+ * unsupported measure 500s the entire stream. Backend gap tracked in
+ * second-brain#219.
  */
 import { test, expect } from '@playwright/test';
 
@@ -69,12 +70,20 @@ test.describe('/data/portfolios → /data/positions (SOMA)', () => {
     // 4. Switch to the PRODUCT_TYPE × DIRECTED_QUANTITY view. The position
     //    service aggregates server-side: requesting only PRODUCT_TYPE collapses
     //    the result set to one row per product type with summed measures.
+    //    Mirror the view/filter defaults set by PortfolioGrid (TRANSACTION
+    //    view, tradeDate < today, hideZeros) so the assertion exercises the
+    //    same shape the user lands on, just with a different fields/measures
+    //    selection. portfolioId keeps the search scoped to SOMA.
+    const today = new Date().toISOString().slice(0, 10);
     await page.goto(
       `/data/positions?portfolioId=${portfolioId}` +
       `&fields=PRODUCT_TYPE` +
       `&measures=DIRECTED_QUANTITY` +
       `&positionView=DEFAULT_VIEW` +
-      `&positionType=TAX_LOT`,
+      `&positionType=TRANSACTION` +
+      `&tradeDate=${today}` +
+      `&tradeDateOperator=lesser_than` +
+      `&hideZeros=true`,
     );
 
     await expect(page.getByRole('heading', { name: 'Positions' })).toBeVisible({ timeout: 15_000 });
@@ -98,14 +107,16 @@ test.describe('/data/portfolios → /data/positions (SOMA)', () => {
       ).toHaveCount(1);
     }
 
-    // The non-cash product types have a non-zero DIRECTED_QUANTITY rendered as
-    // a $-prefixed amount with two decimals (formatAmount in formatUtils).
-    // CASH is allowed to be $0.00 — SOMA's reported holdings don't include
-    // standalone cash positions.
-    for (const productType of ['NOTE', 'BILL', 'BOND'] as const) {
+    // Every product type has a non-zero DIRECTED_QUANTITY. Under TRANSACTION
+    // view + hideZeros=true the seed shows positive holdings for NOTE/BILL/
+    // BOND and a negative CASH leg (the offsetting cash impact of the bond
+    // purchases). formatAmount uses Intl.NumberFormat USD which renders
+    // negatives as `-$1,234.56` and positives as `$1,234.56`; the regex
+    // accepts either sign.
+    for (const productType of SOMA_PRODUCT_TYPES) {
       const row = dataRows.filter({ has: page.locator('td', { hasText: new RegExp(`^${productType}$`) }) });
       const valueCell = row.locator('td').nth(1);
-      await expect(valueCell).toHaveText(/\$[1-9][\d,]*\.\d{2}/);
+      await expect(valueCell).toHaveText(/^-?\$[1-9][\d,]*\.\d{2}$/);
     }
   });
 });


### PR DESCRIPTION
## Summary

Two follow-ups to PR #122 ('clicking SOMA shows its positions') based on user review:

1. **Default landing URL** — switch `PortfolioGrid.getPositionsUrl` to:
   - `positionType=TRANSACTION` (transaction-rolled-up state, not per tax lot)
   - `tradeDate=<today>&tradeDateOperator=lesser_than` (excludes future-dated/unsettled trades)
   - `hideZeros=true` (drop empty rows)
   - Existing `portfolioId`, fields, measures, `positionView` carry through.

2. **Portfolio scoping survives PositionSelect resubmit** — `PositionSelect.fetchPositions()` previously dropped the inbound `portfolioId` when rebuilding the URL on **Run**, silently widening the query back to all portfolios after the user changed field/measure selections. Now preserved. Closes second-brain#220.

## Why no backend change for SOMA-scoping
`/data/positions/+page.server.ts` already wires `portfolioId` through to `FetchPosition`, which adds `PORTFOLIO_ID = uuid` to the `PositionFilter` (`src/lib/positions.ts:84`). End-to-end scoping was already working at the gRPC layer; the only gap was #220 (`PositionSelect.fetchPositions` URL rebuild). The `+page.server.ts` scoping does **not** absorb #220 — they're separate code paths (server load vs. client form-submit).

## Test changes
- `portfolio-soma-positions.spec.ts` step 4 mirrors the new default URL (TRANSACTION + tradeDate + hideZeros + portfolioId). Strengthened: now asserts **all four** product types (NOTE/BILL/BOND/CASH) have non-zero `DIRECTED_QUANTITY`. Under TRANSACTION view CASH carries the negative offsetting leg of the bond purchases; the regex `/^-?\$[1-9][\d,]*\.\d{2}$/` accepts either sign.
- `PortfolioGrid.test.ts` — refresh hardcoded URL params (was already stale from PR #122's measure trim).

## Test plan
- [x] `npx vitest run src/tests/PortfolioGrid.test.ts` — 8/8 pass
- [x] `npx playwright test src/tests/e2e/portfolio-soma-positions.spec.ts` — 2/2 pass
- [x] `npx svelte-check` — same 163 errors / 210 warnings as `main` (no new errors introduced)
- [x] Manual: clicked SOMA → /data/positions, four product-type rows render with non-zero quantities; CASH shows the negative offset

## Related issues
- Closes second-brain#220 (PositionSelect.fetchPositions drops portfolioId)
- Tracks second-brain#219 (ledger-service `12 UNIMPLEMENTED` for ACCRUED_INTEREST etc — restored measures gated on that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)