### PR TITLE
positions: tradeDate operator <= today (include today's trades)

### DIFF
--- a/src/components/widgets/PortfolioGrid.svelte
+++ b/src/components/widgets/PortfolioGrid.svelte
@@ -31,8 +31,9 @@
 		//   - positionType=TRANSACTION rolls up positions at the transaction
 		//     level (current state), not per tax lot — what a portfolio
 		//     manager wants on first load.
-		//   - tradeDate < today filters out unsettled/future-dated trades so
-		//     the page reflects the as-of-now position.
+		//   - tradeDate <= today excludes future-dated trades while including
+		//     today's. A PM checking their book at end-of-day expects trades
+		//     booked today to appear.
 		//   - hideZeros suppresses positions whose every measure is zero.
 		//   - portfolioId scopes the search to the clicked portfolio (SOMA in
 		//     the seeded dataset). The /data/positions page-server already
@@ -46,7 +47,7 @@
 			positionView: 'DEFAULT_VIEW',
 			positionType: 'TRANSACTION',
 			tradeDate: today,
-			tradeDateOperator: 'lesser_than',
+			tradeDateOperator: 'lesser_than_or_equals',
 			hideZeros: 'true',
 		});
 		return `/data/positions?${params.toString()}`;

--- a/src/components/widgets/PositionSelect.svelte
+++ b/src/components/widgets/PositionSelect.svelte
@@ -37,7 +37,11 @@
 
   let cusipInput: string = "";
   let tradeDateInput: string = "";
-  let tradeDateOperator: "greater_than" | "lesser_than" | "" = "";
+  let tradeDateOperator:
+    | "greater_than"
+    | "lesser_than"
+    | "lesser_than_or_equals"
+    | "" = "";
   let assetClassInput: string = "";
   let hideZeros: boolean = false;
 
@@ -143,11 +147,13 @@
       if (
         tradeDateOperatorFromUrl &&
         (tradeDateOperatorFromUrl === "greater_than" ||
-          tradeDateOperatorFromUrl === "lesser_than")
+          tradeDateOperatorFromUrl === "lesser_than" ||
+          tradeDateOperatorFromUrl === "lesser_than_or_equals")
       ) {
         tradeDateOperator = tradeDateOperatorFromUrl as
           | "greater_than"
-          | "lesser_than";
+          | "lesser_than"
+          | "lesser_than_or_equals";
       }
 
       if (assetClassInput) {
@@ -249,6 +255,7 @@
         <option value="">Select operator...</option>
         <option value="greater_than">Greater Than</option>
         <option value="lesser_than">Lesser Than</option>
+        <option value="lesser_than_or_equals">Lesser Than or Equal</option>
       </select>
     </div>
     <div class="text-white">

--- a/src/lib/positions.ts
+++ b/src/lib/positions.ts
@@ -48,7 +48,7 @@ export async function FetchPosition(
     sortDirection: 'asc' | 'desc' = 'asc',
     cusip?: string,
     tradeDate?: string,
-    tradeDateOperator?: 'greater_than' | 'lesser_than',
+    tradeDateOperator?: 'greater_than' | 'lesser_than' | 'lesser_than_or_equals',
     assetClass?: string,
     portfolioId?: string,
     apiKey?: string
@@ -65,9 +65,12 @@ export async function FetchPosition(
     // Add TRADE_DATE filter if provided
     if (tradeDate && tradeDate.trim() !== "" && tradeDateOperator) {
         const tradeDateObj = new Date(tradeDate);
-        const operator = tradeDateOperator === 'greater_than'
-            ? PositionFilterOperator.MORE_THAN
-            : PositionFilterOperator.LESS_THAN;
+        const operator =
+            tradeDateOperator === 'greater_than'
+                ? PositionFilterOperator.MORE_THAN
+                : tradeDateOperator === 'lesser_than_or_equals'
+                    ? PositionFilterOperator.LESS_THAN_OR_EQUALS
+                    : PositionFilterOperator.LESS_THAN;
         positionFilter.addFilter(FieldProto.TRADE_DATE, operator, tradeDateObj);
     }
 

--- a/src/routes/(authenticated)/data/positions/+page.server.ts
+++ b/src/routes/(authenticated)/data/positions/+page.server.ts
@@ -149,7 +149,13 @@ export async function load({ locals, request }) {
     validSortDirection,
     cusip || undefined,
     tradeDate || undefined,
-    tradeDateOperator === 'greater_than' ? 'greater_than' : tradeDateOperator === 'lesser_than' ? 'lesser_than' : undefined,
+    tradeDateOperator === 'greater_than'
+      ? 'greater_than'
+      : tradeDateOperator === 'lesser_than_or_equals'
+        ? 'lesser_than_or_equals'
+        : tradeDateOperator === 'lesser_than'
+          ? 'lesser_than'
+          : undefined,
     assetClass || undefined,
     portfolioId || undefined,
     locals.user?.apiKey

--- a/src/tests/PortfolioGrid.test.ts
+++ b/src/tests/PortfolioGrid.test.ts
@@ -61,7 +61,7 @@ describe('PortfolioGrid', () => {
 				positionView: 'DEFAULT_VIEW',
 				positionType: 'TRANSACTION',
 				tradeDate: today,
-				tradeDateOperator: 'lesser_than',
+				tradeDateOperator: 'lesser_than_or_equals',
 				hideZeros: 'true',
 			});
 			const expectedUrl = `/data/positions?${expectedParams.toString()}`;
@@ -92,7 +92,7 @@ describe('PortfolioGrid', () => {
 		expect(params.get('positionView')).toBe('DEFAULT_VIEW');
 		expect(params.get('positionType')).toBe('TRANSACTION');
 		expect(params.get('tradeDate')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-		expect(params.get('tradeDateOperator')).toBe('lesser_than');
+		expect(params.get('tradeDateOperator')).toBe('lesser_than_or_equals');
 		expect(params.get('hideZeros')).toBe('true');
 	});
 

--- a/src/tests/e2e/portfolio-soma-positions.spec.ts
+++ b/src/tests/e2e/portfolio-soma-positions.spec.ts
@@ -17,8 +17,9 @@
  * Default-URL filter set (mirrored both in PortfolioGrid.getPositionsUrl and
  * step 4 of this test):
  *   - positionType=TRANSACTION (transaction-rolled-up state, not per tax lot).
- *   - tradeDate=<today> & tradeDateOperator=lesser_than excludes future-dated
- *     / unsettled trades so the page reflects the as-of-now position.
+ *   - tradeDate=<today> & tradeDateOperator=lesser_than_or_equals excludes
+ *     future-dated trades while including those booked today, so the page
+ *     reflects the as-of-now position.
  *   - hideZeros=true suppresses fully-zero rows.
  *   - portfolioId scopes the search to the clicked portfolio.
  *
@@ -71,7 +72,7 @@ test.describe('/data/portfolios → /data/positions (SOMA)', () => {
     //    service aggregates server-side: requesting only PRODUCT_TYPE collapses
     //    the result set to one row per product type with summed measures.
     //    Mirror the view/filter defaults set by PortfolioGrid (TRANSACTION
-    //    view, tradeDate < today, hideZeros) so the assertion exercises the
+    //    view, tradeDate <= today, hideZeros) so the assertion exercises the
     //    same shape the user lands on, just with a different fields/measures
     //    selection. portfolioId keeps the search scoped to SOMA.
     const today = new Date().toISOString().slice(0, 10);
@@ -82,7 +83,7 @@ test.describe('/data/portfolios → /data/positions (SOMA)', () => {
       `&positionView=DEFAULT_VIEW` +
       `&positionType=TRANSACTION` +
       `&tradeDate=${today}` +
-      `&tradeDateOperator=lesser_than` +
+      `&tradeDateOperator=lesser_than_or_equals` +
       `&hideZeros=true`,
     );
 


### PR DESCRIPTION
## Summary

Follow-up to #123. The default landing URL was `tradeDate < today`, which excluded trades booked today. A PM checking their book at end-of-day expects today's trades to be visible — switch the operator to `<=`.

Wires a third URL operator string `lesser_than_or_equals` end-to-end:
- `FetchPosition` (`src/lib/positions.ts`) maps it to `PositionFilterOperator.LESS_THAN_OR_EQUALS`.
- `+page.server.ts` validates and forwards the third value.
- `PositionSelect` accepts it from the URL and adds a **Lesser Than or Equal** option to the operator dropdown for manual use.
- `PortfolioGrid.getPositionsUrl` switches its default to it.

## Why a separate PR
This was originally a second commit on the #123 branch. #123 merged before GitHub's PR head ref refreshed, so the operator commit was left behind. Cherry-picked clean onto current main.

## Test plan
- [x] `npx vitest run src/tests/PortfolioGrid.test.ts` — 8/8 pass
- [x] `npx playwright test src/tests/e2e/portfolio-soma-positions.spec.ts` — 2/2 pass
- [x] `npx svelte-check` — no new errors (163/210, same as main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)