### PR TITLE
ui: collapse nested scrollbars — page-level wrapper owns scrolling (#223)

### DIFF
--- a/src/components/widgets/PortfolioGrid.svelte
+++ b/src/components/widgets/PortfolioGrid.svelte
@@ -133,8 +133,10 @@
 <style lang="scss">
 	@import "../../styles/grid-table";
 
+	// No overflow-x here: we let the page-level wrapper own horizontal
+	// scrolling so the user sees one global scrollbar instead of one per
+	// grid (second-brain#223).
 	.table-wrapper {
-		overflow-x: auto;
 		width: 100%;
 	}
 

--- a/src/components/widgets/PositionGrid.svelte
+++ b/src/components/widgets/PositionGrid.svelte
@@ -293,8 +293,10 @@
 <style lang="scss">
 	@import "../../styles/grid-table";
 
+	// No overflow-x here: we let the page-level wrapper own horizontal
+	// scrolling so the user sees one global scrollbar instead of one per
+	// grid (second-brain#223).
 	.table-wrapper {
-		overflow-x: auto;
 		width: 100%;
 	}
 

--- a/src/components/widgets/SecurityGrid.svelte
+++ b/src/components/widgets/SecurityGrid.svelte
@@ -146,8 +146,10 @@
 <style lang="scss">
   @import "../../styles/grid-table";
 
+  // No overflow-x here: we let the page-level wrapper own horizontal
+  // scrolling so the user sees one global scrollbar instead of one per
+  // grid (second-brain#223).
   .table-wrapper {
-    overflow-x: auto;
     width: 100%;
   }
 

--- a/src/components/widgets/TransactionGrid.svelte
+++ b/src/components/widgets/TransactionGrid.svelte
@@ -124,8 +124,10 @@
 <style lang="scss">
   @import "../../styles/grid-table";
 
+  // No overflow-x here: we let the page-level wrapper own horizontal
+  // scrolling so the user sees one global scrollbar instead of one per
+  // grid (second-brain#223).
   .table-wrapper {
-    overflow-x: auto;
     width: 100%;
   }
 

--- a/src/components/widgets/TransactionHistoryGrid.svelte
+++ b/src/components/widgets/TransactionHistoryGrid.svelte
@@ -44,8 +44,10 @@
 <style lang="scss">
 	@import "../../styles/grid-table";
 
+	// No overflow-x here: we let the page-level wrapper own horizontal
+	// scrolling so the user sees one global scrollbar instead of one per
+	// grid (second-brain#223).
 	.table-wrapper {
-		overflow-x: auto;
 		width: 100%;
 	}
 

--- a/src/routes/(authenticated)/data/catalog/+page.svelte
+++ b/src/routes/(authenticated)/data/catalog/+page.svelte
@@ -286,9 +286,9 @@
     margin: 20px 0 4px 0;
   }
 
-  /* Table wrapper — matches SecurityGrid */
+  /* Table wrapper — matches SecurityGrid. No overflow-x: page-level
+     wrapper owns scrolling (second-brain#223). */
   .table-wrapper {
-    overflow-x: auto;
     width: 100%;
     margin-bottom: 8px;
   }

--- a/src/routes/(authenticated)/data/cpi_index/+page.svelte
+++ b/src/routes/(authenticated)/data/cpi_index/+page.svelte
@@ -92,7 +92,7 @@
 <div class="w-screen h-full flex">
   <DashboardSideBar {data} />
 
-  <div class="h-full w-full dashboard-container" style="overflow-y: auto;">
+  <div class="h-full w-full dashboard-container" style="overflow: auto;">
     <div class="portfolio_container px-10 py-7">
       <h1 class="page-title">{pageTitle}</h1>
       <p class="page-subtitle">{pageSubtitle}</p>
@@ -235,8 +235,9 @@
     margin-bottom: 12px;
   }
 
+  // No overflow-x here: page-level wrapper owns scrolling (second-brain#223).
   .table-scroll {
-    overflow-x: auto;
+    width: 100%;
   }
 
   table {

--- a/src/routes/(authenticated)/data/curves/+page.svelte
+++ b/src/routes/(authenticated)/data/curves/+page.svelte
@@ -231,8 +231,9 @@
     min-height: 400px;
   }
 
+  // No overflow-x here: page-level wrapper owns scrolling (second-brain#223).
   .table-wrapper {
-    overflow-x: auto;
+    width: 100%;
   }
 
   .par-col { color: #60a5fa; font-weight: 600; font-variant-numeric: tabular-nums; }

--- a/src/routes/(authenticated)/data/prices/+page.svelte
+++ b/src/routes/(authenticated)/data/prices/+page.svelte
@@ -390,8 +390,9 @@
     min-height: 420px;  // chart + range slider + range selector
   }
 
+  // No overflow-x here: page-level wrapper owns scrolling (second-brain#223).
   .table-wrapper {
-    overflow-x: auto;
+    width: 100%;
   }
 
 

--- a/src/routes/(authenticated)/data/treasury_curve/+page.svelte
+++ b/src/routes/(authenticated)/data/treasury_curve/+page.svelte
@@ -64,7 +64,7 @@
 <div class="w-screen h-full flex">
   <DashboardSideBar {data} />
 
-  <div class="h-full w-full dashboard-container" style="overflow-y: auto;">
+  <div class="h-full w-full dashboard-container" style="overflow: auto;">
     <div class="portfolio_container px-10 py-7">
   <h1 class="page-title">On-the-Run Treasury Yield Curve</h1>
   <p class="date-subtitle">as of {displayDate}</p>
@@ -183,8 +183,8 @@
     margin-bottom: 16px;
   }
 
+  // No overflow-x here: page-level wrapper owns scrolling (second-brain#223).
   .table-scroll {
-    overflow-x: auto;
     margin-bottom: 24px;
   }
 

--- a/src/tests/e2e/portfolio-soma-transactions.spec.ts
+++ b/src/tests/e2e/portfolio-soma-transactions.spec.ts
@@ -52,5 +52,24 @@ test.describe('/data/portfolios → /data/transactions (SOMA)', () => {
     // returned data (rather than an empty page hidden behind the heading).
     await expect(dataRows.first()).toBeVisible({ timeout: 10_000 });
     expect(await dataRows.count()).toBeGreaterThan(0);
+
+    // second-brain#223: the table-wrapper around the grid must NOT have its
+    // own overflow scroll. Page-level .dashboard-container owns scrolling so
+    // the user sees a single horizontal/vertical scrollbar.
+    const tableWrapper = page.locator('.table-wrapper').first();
+    const wrapperOverflow = await tableWrapper.evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return { x: cs.overflowX, y: cs.overflowY };
+    });
+    expect(wrapperOverflow.x).toBe('visible');
+    expect(wrapperOverflow.y).toBe('visible');
+
+    // .dashboard-container, by contrast, must be the scroll owner.
+    const dashOverflow = await page.locator('.dashboard-container').evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return { x: cs.overflowX, y: cs.overflowY };
+    });
+    expect(['auto', 'scroll']).toContain(dashOverflow.x);
+    expect(['auto', 'scroll']).toContain(dashOverflow.y);
   });
 });


### PR DESCRIPTION
Closes second-brain#223.

## Summary

Every data page was rendering **two scrollbars on each axis**: the grid's `.table-wrapper` had `overflow-x: auto` and the page's `.dashboard-container` had `overflow: auto`. A wide table produced an inner horizontal scrollbar plus a page-level one (and similarly vertical when content was long).

Fix: the page-level wrapper is the single scroll owner. Drop `overflow-x: auto` from every grid component and page-embedded table wrapper.

## Audit + changes (per issue checklist)

| File | Before | After |
|---|---|---|
| `TransactionGrid.svelte` | `.table-wrapper { overflow-x: auto }` | dropped |
| `PositionGrid.svelte` | same | dropped |
| `PortfolioGrid.svelte` | same | dropped |
| `SecurityGrid.svelte` | same | dropped |
| `TransactionHistoryGrid.svelte` | same | dropped |
| `/data/curves/+page.svelte` | `.table-wrapper { overflow-x: auto }` | dropped |
| `/data/prices/+page.svelte` | same | dropped (autocomplete dropdown's `max-height: 240px; overflow-y: auto` kept — that's a UI control, not a grid) |
| `/data/catalog/+page.svelte` | `.table-wrapper { overflow-x: auto }` | dropped |
| `/data/cpi_index/+page.svelte` | `.table-scroll { overflow-x: auto }` + page wrapper `overflow-y: auto` | grid dropped; page wrapper bumped to `overflow: auto` so a wide table still scrolls — just at the page level |
| `/data/treasury_curve/+page.svelte` | `.table-scroll { overflow-x: auto }` + page wrapper `overflow-y: auto` | same shape as cpi_index |

## Sticky behaviour

`.action-col { position: sticky; left: 0 }` (PortfolioGrid) and sticky `<thead>` (cpi_index) now pin against the page-level scroll container instead of the dropped inner one — which is exactly what the issue asks for: **one** horizontal scrollbar, with sticky columns/headers pinning against it.

## Out of scope (per issue)

- Virtual scrolling, frozen-column features, mobile breakpoint behaviour.
- Calculator components (`BondCalculator`, `FrnCalculator`, `TipsCalculator`) keep their cashflow sub-table `max-height: 220px; overflow-y: auto` — calculators aren't on the audit list and the constrained sub-grid is a deliberate design choice.

## Test plan

- [x] `npx playwright test` — 6/6 pass (positions / transactions / prices specs)
- [x] `portfolio-soma-transactions.spec.ts` strengthened: now asserts `.table-wrapper` resolved `overflow-x` / `overflow-y` are `visible` and `.dashboard-container` is `auto`/`scroll` — guards against regression
- [x] `npx vitest run src/tests/PortfolioGrid.test.ts` — 9/9 pass
- [x] `npx svelte-check` — 163 errors / 210 warnings, **same as main** (CSS-only changes)
- [x] Manual: clicked Txns on SOMA → /data/transactions, single page-level horizontal scrollbar, table headers stay visible while scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)