### PR TITLE
ui: extract URL-state lib + refactor PositionSelect (#226 phase 0)

### DIFF
--- a/src/components/widgets/PositionSelect.svelte
+++ b/src/components/widgets/PositionSelect.svelte
@@ -5,6 +5,7 @@
   import measure_pkg from "@fintekkers/ledger-models/node/fintekkers/models/position/measure_pb.js";
   import position_pkg from "@fintekkers/ledger-models/node/fintekkers/models/position/position_pb.js";
   import { onMount } from "svelte";
+  import { buildFilterUrl } from "$lib/filters/urlState";
 
   const { FieldProto } = pkg;
 
@@ -59,46 +60,36 @@
   }
 
   function fetchPositions() {
-    const selectedFieldsString = selectedFields.map(unformatName).join(",");
-    const selectedMeasuresString = selectedMeasures.map(unformatName).join(",");
+    if (typeof window === "undefined") return;
 
-    // Unformat selected position view and type
-    const unformattedPositionView = selectedPositionView.map(unformatName);
-    const unformattedPositionType = selectedPositionType.map(unformatName);
+    const trimmedTradeDate = tradeDateInput.trim();
+    // tradeDate and its operator are a coupled pair: only emit one if the
+    // other is also set, otherwise the page-server filter is half-applied.
+    const tradeDateOverride =
+      trimmedTradeDate && tradeDateOperator ? trimmedTradeDate : undefined;
+    const tradeDateOperatorOverride =
+      trimmedTradeDate && tradeDateOperator ? tradeDateOperator : undefined;
 
-    let url = `/data/positions?positionView=${unformattedPositionView}&positionType=${unformattedPositionType}&fields=${selectedFieldsString}&measures=${selectedMeasuresString}`;
-
-    // Add CUSIP to URL if provided
-    if (cusipInput && cusipInput.trim() !== "") {
-      url += `&cusip=${encodeURIComponent(cusipInput.trim())}`;
-    }
-
-    // Add TRADE_DATE filter to URL if provided
-    if (tradeDateInput && tradeDateInput.trim() !== "" && tradeDateOperator) {
-      url += `&tradeDate=${encodeURIComponent(tradeDateInput.trim())}`;
-      url += `&tradeDateOperator=${encodeURIComponent(tradeDateOperator)}`;
-    }
-
-    // Add ASSET_CLASS filter to URL if provided
-    if (assetClassInput && assetClassInput.trim() !== "") {
-      url += `&assetClass=${encodeURIComponent(assetClassInput.trim())}`;
-    }
-
-    // Add hideZeros filter to URL
-    if (hideZeros) {
-      url += `&hideZeros=true`;
-    }
-
-    // Preserve portfolioId from the inbound URL so re-running the form keeps
-    // the search scoped to the portfolio the user navigated in from. Without
-    // this, clicking SOMA → /positions → "Run" would silently widen the
-    // query to all portfolios. Tracked in second-brain#220.
-    if (typeof window !== "undefined") {
-      const inboundPortfolioId = new URLSearchParams(window.location.search).get("portfolioId");
-      if (inboundPortfolioId) {
-        url += `&portfolioId=${encodeURIComponent(inboundPortfolioId)}`;
-      }
-    }
+    const url = buildFilterUrl(
+      "/data/positions",
+      new URLSearchParams(window.location.search),
+      {
+        positionView: selectedPositionView.map(unformatName).join(","),
+        positionType: selectedPositionType.map(unformatName).join(","),
+        fields: selectedFields.map(unformatName).join(","),
+        measures: selectedMeasures.map(unformatName).join(","),
+        cusip: cusipInput.trim() || undefined,
+        tradeDate: tradeDateOverride,
+        tradeDateOperator: tradeDateOperatorOverride,
+        assetClass: assetClassInput.trim() || undefined,
+        hideZeros: hideZeros ? "true" : undefined,
+      },
+      // Inherit portfolioId so re-submitting the form keeps the search
+      // scoped to the portfolio the user navigated in from (second-brain#220
+      // / PR #123). The list of inheritKeys is the only place this rule
+      // lives now — adding more ambient context in future is one-line.
+      ["portfolioId"],
+    );
 
     window.location.href = url;
   }

--- a/src/lib/filters/urlState.test.ts
+++ b/src/lib/filters/urlState.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'vitest';
+import { buildFilterUrl } from './urlState';
+
+describe('buildFilterUrl', () => {
+  test('empty overrides + empty current returns just the pathname', () => {
+    expect(buildFilterUrl('/data/positions', new URLSearchParams(), {})).toBe(
+      '/data/positions',
+    );
+  });
+
+  test('non-empty string override is set', () => {
+    expect(
+      buildFilterUrl('/data/positions', new URLSearchParams(), { fields: 'A,B' }),
+    ).toBe('/data/positions?fields=A%2CB');
+  });
+
+  test('empty-string override is treated as absent', () => {
+    expect(
+      buildFilterUrl('/data/positions', new URLSearchParams(), {
+        fields: 'A',
+        cusip: '',
+      }),
+    ).toBe('/data/positions?fields=A');
+  });
+
+  test('undefined override is treated as absent', () => {
+    expect(
+      buildFilterUrl('/data/positions', new URLSearchParams(), {
+        fields: 'A',
+        cusip: undefined,
+      }),
+    ).toBe('/data/positions?fields=A');
+  });
+
+  test('inheritKeys preserves param from current when override absent', () => {
+    const current = new URLSearchParams('portfolioId=abc-123');
+    expect(
+      buildFilterUrl('/data/positions', current, { fields: 'A' }, ['portfolioId']),
+    ).toBe('/data/positions?fields=A&portfolioId=abc-123');
+  });
+
+  test('inheritKeys does NOT add a param that is missing from current', () => {
+    expect(
+      buildFilterUrl('/data/positions', new URLSearchParams(), { fields: 'A' }, [
+        'portfolioId',
+      ]),
+    ).toBe('/data/positions?fields=A');
+  });
+
+  test('override wins over current for the same key', () => {
+    const current = new URLSearchParams('portfolioId=old&fields=stale');
+    expect(
+      buildFilterUrl(
+        '/data/positions',
+        current,
+        { portfolioId: 'new', fields: 'fresh' },
+        ['portfolioId'],
+      ),
+    ).toBe('/data/positions?portfolioId=new&fields=fresh');
+  });
+
+  test('null override removes a key that would otherwise inherit', () => {
+    const current = new URLSearchParams('portfolioId=abc-123');
+    expect(
+      buildFilterUrl(
+        '/data/positions',
+        current,
+        { fields: 'A', portfolioId: null },
+        ['portfolioId'],
+      ),
+    ).toBe('/data/positions?fields=A');
+  });
+
+  test('insertion order: overrides first (in declaration order), then inheritKeys', () => {
+    const current = new URLSearchParams('portfolioId=p1&assetClass=fixed');
+    expect(
+      buildFilterUrl(
+        '/data/positions',
+        current,
+        { fields: 'A', measures: 'M' },
+        ['portfolioId', 'assetClass'],
+      ),
+    ).toBe('/data/positions?fields=A&measures=M&portfolioId=p1&assetClass=fixed');
+  });
+
+  test('special characters get URL-encoded', () => {
+    expect(
+      buildFilterUrl('/data/positions', new URLSearchParams(), {
+        cusip: 'a b/c',
+      }),
+    ).toBe('/data/positions?cusip=a+b%2Fc');
+  });
+
+  test('PositionSelect call shape — inherits portfolioId, applies form overrides', () => {
+    const current = new URLSearchParams('portfolioId=soma-uuid&fields=stale');
+    const url = buildFilterUrl(
+      '/data/positions',
+      current,
+      {
+        positionView: 'DEFAULT_VIEW',
+        positionType: 'TRANSACTION',
+        fields: 'SECURITY_DESCRIPTION',
+        measures: 'DIRECTED_QUANTITY',
+        cusip: undefined,
+        tradeDate: '2026-05-06',
+        tradeDateOperator: 'lesser_than_or_equals',
+        assetClass: undefined,
+        hideZeros: 'true',
+      },
+      ['portfolioId'],
+    );
+    expect(url).toBe(
+      '/data/positions?positionView=DEFAULT_VIEW&positionType=TRANSACTION&fields=SECURITY_DESCRIPTION&measures=DIRECTED_QUANTITY&tradeDate=2026-05-06&tradeDateOperator=lesser_than_or_equals&hideZeros=true&portfolioId=soma-uuid',
+    );
+  });
+});

--- a/src/lib/filters/urlState.ts
+++ b/src/lib/filters/urlState.ts
@@ -1,0 +1,65 @@
+/**
+ * URL-state helper for filter forms.
+ *
+ * Phase 0 of second-brain#226. Extracts the inherit-and-override URL-param
+ * pattern that PR #123 introduced in PositionSelect (closing #220, where the
+ * Run button silently dropped the inbound portfolioId and widened the query
+ * back to all portfolios). The same shape will surface in every other filter
+ * panel as we adopt #226's Option-B primitives — having one place to change
+ * the rules avoids re-fixing the same bug-shape per page.
+ *
+ * Behavior contract:
+ *   buildFilterUrl(path, current, overrides, inheritKeys)
+ *
+ *   - `overrides` are the form's authoritative view: a non-empty string sets
+ *     the param; null deletes it (even if it would otherwise inherit);
+ *     undefined/empty-string falls through (treat the override as absent).
+ *   - `inheritKeys` are param names that should carry over from the current
+ *     URL when the override is absent. This is the #220 fix made generic:
+ *     the form preserves scope params (portfolioId today; tomorrow whatever
+ *     other ambient context the page lives in).
+ *   - Insertion order in the returned URL: keys in `overrides` first (in the
+ *     order the caller declared them), then any inherited keys not yet set.
+ *     This makes the URL readable and gives the call site control over
+ *     ordering for tests.
+ */
+
+export type FilterOverrides = Record<string, string | null | undefined>;
+
+export function buildFilterUrl(
+  pathname: string,
+  current: URLSearchParams,
+  overrides: FilterOverrides,
+  inheritKeys: readonly string[] = [],
+): string {
+  const params = new URLSearchParams();
+
+  // Apply overrides in declaration order. Empty strings are treated as
+  // "param absent" — matches the PositionSelect convention where empty
+  // text inputs don't appear in the URL. null is a sentinel meaning
+  // "explicitly remove this from the inherited set" (no-op when there's
+  // nothing to inherit).
+  const explicitlyRemoved = new Set<string>();
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) {
+      explicitlyRemoved.add(key);
+      continue;
+    }
+    if (value === undefined || value === '') continue;
+    params.set(key, value);
+  }
+
+  // Inherit any requested keys from the current URL that the overrides
+  // didn't already set or explicitly remove.
+  for (const key of inheritKeys) {
+    if (params.has(key)) continue;
+    if (explicitlyRemoved.has(key)) continue;
+    const inbound = current.get(key);
+    if (inbound !== null && inbound !== '') {
+      params.set(key, inbound);
+    }
+  }
+
+  const qs = params.toString();
+  return qs ? `${pathname}?${qs}` : pathname;
+}


### PR DESCRIPTION
Phase 0 of second-brain#226 (Option B, 4-phase rollout). **Pure refactor — no UX change, no new pages affected.**

Closes the #220-class bug-shape forever: the inherit-existing-URL-params + apply-overrides + navigate logic now lives in **one** place, not one-per-page.

## API

```ts
// src/lib/filters/urlState.ts
export function buildFilterUrl(
  pathname: string,
  current: URLSearchParams,
  overrides: Record<string, string | null | undefined>,
  inheritKeys: readonly string[] = [],
): string
```

- **`overrides`** are the form's authoritative view: non-empty string sets the param; empty string / `undefined` is treated as absent; `null` deletes (even from inheritance).
- **`inheritKeys`** are param names preserved from `current` when not set by overrides. This is the #220 fix made generic — adding more ambient context (e.g. a future `tenantId`) is one-line.

### API decisions (and why)

| Decision | Why |
|---|---|
| Plain function, not a Svelte action/store | Call site is one-shot at form-submit, not reactive. A store adds lifecycle without buying anything. |
| `overrides` as a plain `Record`, not a fluent builder | Form-derived state is already a plain object; call site reads as 'here is my form, here is what I inherit'. |
| `inheritKeys` as a separate readonly array | Inheritance is a different concept from override (preserve-from-URL vs apply-from-form), so they get separate arguments instead of being conflated as sentinel values. |
| Empty string treated as absent | Matches existing PositionSelect behavior (empty text inputs don't appear in the URL). Callers wanting to *clear* an inherited param pass `null`. |
| Insertion order: overrides first (declaration order), then inheritKeys | URL is readable; call site controls ordering for tests. |

## Refactor: `PositionSelect.fetchPositions`

Before: ~40 lines of conditional URL building, with the `portfolioId`-preservation block buried at the bottom.

After: a single `buildFilterUrl` call. The `portfolioId` rule is now expressed as `inheritKeys: ['portfolioId']`. Adding more ambient context in the future is one line.

`tradeDate` + `tradeDateOperator` are coupled in a small helper above the call (emit both or neither — preserving the original 'half-applied filter' guard).

## Tests

**New:** `src/lib/filters/urlState.test.ts` — 11 unit tests, call-table style:
- empty / single override / empty-string override / undefined override
- inheritKeys preserves from current
- inheritKeys is no-op when key missing from current
- override wins over current
- `null` deletes from inheritance
- insertion order
- special-character encoding
- the PositionSelect-shaped real case (full form + portfolioId inheritance)

**No-regression coverage** for the PositionSelect refactor:
- Playwright **6/6** (positions / transactions / prices specs)
- PortfolioGrid unit **9/9**
- bond-engine-path-request-shape **2/2**
- One-off smoke (deleted post-verification): `goto /data/positions?portfolioId=…&…` → click **Fetch** → confirmed `portfolioId` survives the form submit. This is exactly the #220 regression that PR #123 originally fixed.
- svelte-check **163 errors / 210 warnings — same as main** (no new errors).

## Out of scope (per issue)

- Phase 1: `/data/securities` filter extension (assetClass / issuerName / securityType / all identifier types).
- Phase 2: `IdentifierFilter` primitive shared by `/data/securities` + `/data/positions`.
- Other pages adopting `urlState.ts` beyond `PositionSelect` — those happen organically as later phases land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)