### PR TITLE
DateFilter primitive + /data/positions migration (Phase 3 of #226, PR-A)

### DIFF
--- a/src/components/filters/DateFilter.svelte
+++ b/src/components/filters/DateFilter.svelte
@@ -1,0 +1,133 @@
+<script lang="ts" context="module">
+  /**
+   * Operator vocabulary for date filters. Currently sourced from the
+   * tradeDateOperator shape PositionSelect already used (preserved end-
+   * to-end for URL compat with /data/positions/+page.server.ts). PR-B
+   * (transactions + securities migrations) adopts the same set; if a
+   * future consumer needs `equals` / `greater_than_or_equals`, extend
+   * here and the dropdown picks them up automatically.
+   *
+   * Note on shape sharing with IdentifierFilter: IdentifierFilter sources
+   * its names from ledger-models's `Identifier.getAllTypeNames()` so a
+   * proto enum addition propagates without UI edits. Date operators
+   * have no proto enum to share — they're URL-string conventions in
+   * /data/*+page.server.ts, so a hand-typed union is the right shape.
+   * Documented for the Phase 3+ "shared operator-label list" thought:
+   * not factored because the two consumers (identifier-types vs date-
+   * operators) genuinely have different sources of truth.
+   */
+  export type DateOperator =
+    | 'greater_than'
+    | 'lesser_than'
+    | 'lesser_than_or_equals';
+
+  export const DEFAULT_DATE_OPERATORS: readonly DateOperator[] = [
+    'greater_than',
+    'lesser_than',
+    'lesser_than_or_equals',
+  ] as const;
+
+  export const DEFAULT_DATE_OPERATOR_LABELS: Record<DateOperator, string> = {
+    greater_than: 'Greater Than',
+    lesser_than: 'Lesser Than',
+    lesser_than_or_equals: 'Lesser Than or Equal',
+  };
+</script>
+
+<script lang="ts">
+  /**
+   * Phase 3 of second-brain#226 — second composable filter primitive.
+   * Matches IdentifierFilter's API conventions (Phase 2): two-way bound
+   * state, no URL knowledge, class pass-through, optional slot below
+   * the value input. See IdentifierFilter.svelte for the full Phase 2
+   * design rationale.
+   *
+   * Owns: ISO-date input + (optional) operator dropdown.
+   *
+   * Does NOT own:
+   *   - URL <-> form sync. The page builds + parses URL params (e.g.
+   *     ?tradeDate=…&tradeDateOperator=…) and binds the result here.
+   *   - The (date, operator) coupling rule — both required for a valid
+   *     filter, neither alone is meaningful. The parent enforces that
+   *     when emitting to URL (see PositionSelect.fetchPositions for
+   *     the canonical pattern).
+   *
+   * URL/serialization staying outside is consistent with IdentifierFilter:
+   * /data/positions, /data/transactions, /data/securities each name their
+   * date param differently (tradeDate vs issueDate vs settlementDate),
+   * and the operator-naming convention may diverge in the future. Keeping
+   * this primitive form-scoped means each page's URL can evolve without
+   * touching shared code.
+   */
+
+  // Two-way bindings — parent owns the state.
+  export let date: string = '';
+  export let operator: DateOperator | '' = '';
+
+  // Optional: render only the date input, no operator. Useful when the
+  // consumer wants an absolute equals-this-date filter without exposing
+  // the operator switcher.
+  export let withOperator: boolean = true;
+
+  // Operator subset + label override. Defaults match the existing
+  // /data/positions tradeDateOperator vocabulary.
+  export let operators: readonly DateOperator[] = DEFAULT_DATE_OPERATORS;
+  export let operatorLabels: Partial<Record<DateOperator, string>> = {};
+
+  // Class pass-through (matches IdentifierFilter). Consumer supplies
+  // its own page-specific styling on the rendered <input>/<select>.
+  export let inputClass: string = '';
+  export let selectClass: string = '';
+  export let inputId: string = 'date-filter-value';
+
+  $: resolvedLabels = { ...DEFAULT_DATE_OPERATOR_LABELS, ...operatorLabels };
+</script>
+
+<div class="date-filter">
+  <div class="value-col">
+    <input
+      type="date"
+      id={inputId}
+      class={inputClass}
+      bind:value={date}
+      on:change
+      on:input
+    />
+    <slot />
+  </div>
+  {#if withOperator}
+    <div class="operator-col">
+      <select
+        class={selectClass}
+        bind:value={operator}
+        disabled={!date}
+        aria-label="Date operator"
+      >
+        <option value="">Select operator...</option>
+        {#each operators as op}
+          <option value={op}>{resolvedLabels[op]}</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  .date-filter {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+
+  // position: relative so the consumer can absolutely-position helper
+  // UI under the date input via the default slot (matches the
+  // IdentifierFilter slot anchoring convention).
+  .value-col {
+    flex: 1 1 auto;
+    position: relative;
+  }
+
+  .operator-col {
+    flex: 0 0 auto;
+  }
+</style>

--- a/src/components/filters/DateFilter.test.ts
+++ b/src/components/filters/DateFilter.test.ts
@@ -1,0 +1,108 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+import DateFilter from './DateFilter.svelte';
+import type { DateOperator } from './DateFilter.svelte';
+
+describe('DateFilter', () => {
+  test('renders both date input and operator select by default (withOperator=true)', () => {
+    const { container } = render(DateFilter);
+    expect(container.querySelector('input[type="date"]')).toBeInTheDocument();
+    expect(container.querySelector('select')).toBeInTheDocument();
+  });
+
+  test('withOperator=false hides the operator select', () => {
+    const { container } = render(DateFilter, { props: { withOperator: false } });
+    expect(container.querySelector('input[type="date"]')).toBeInTheDocument();
+    expect(container.querySelector('select')).toBeNull();
+  });
+
+  test('operator select is disabled when date is empty', () => {
+    const { container } = render(DateFilter);
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select.disabled).toBe(true);
+  });
+
+  test('operator select is enabled once a date is set', () => {
+    const { container } = render(DateFilter, { props: { date: '2026-05-06' } });
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select.disabled).toBe(false);
+  });
+
+  test('default operators render in declared order with friendly labels', () => {
+    const { container } = render(DateFilter, { props: { date: '2026-05-06' } });
+    const options = Array.from(container.querySelectorAll('option')) as HTMLOptionElement[];
+    // [Select operator..., Greater Than, Lesser Than, Lesser Than or Equal]
+    expect(options.map((o) => o.value)).toEqual([
+      '',
+      'greater_than',
+      'lesser_than',
+      'lesser_than_or_equals',
+    ]);
+    expect(options.map((o) => o.text)).toEqual([
+      'Select operator...',
+      'Greater Than',
+      'Lesser Than',
+      'Lesser Than or Equal',
+    ]);
+  });
+
+  test('operators prop restricts the dropdown to a subset', () => {
+    const { container } = render(DateFilter, {
+      props: {
+        date: '2026-05-06',
+        operators: ['greater_than'] as readonly DateOperator[],
+      },
+    });
+    const operatorOptions = (Array.from(container.querySelectorAll('option')) as HTMLOptionElement[])
+      .filter((o) => o.value !== '');
+    expect(operatorOptions.map((o) => o.value)).toEqual(['greater_than']);
+  });
+
+  test('operatorLabels prop overrides specific operator labels', () => {
+    const { container } = render(DateFilter, {
+      props: {
+        date: '2026-05-06',
+        operatorLabels: { greater_than: 'After' },
+      },
+    });
+    const greaterThanOption = (Array.from(container.querySelectorAll('option')) as HTMLOptionElement[])
+      .find((o) => o.value === 'greater_than');
+    expect(greaterThanOption?.text).toBe('After');
+  });
+
+  test('two-way bind: changing the date input propagates to the bound value', async () => {
+    const { container } = render(DateFilter, { props: { date: '' } });
+    const input = container.querySelector('input[type="date"]') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: '2026-05-06' } });
+    expect(input.value).toBe('2026-05-06');
+  });
+
+  test('two-way bind: changing operator propagates', async () => {
+    const { container } = render(DateFilter, {
+      props: { date: '2026-05-06', operator: '' as DateOperator | '' },
+    });
+    const select = container.querySelector('select') as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: 'lesser_than_or_equals' } });
+    expect(select.value).toBe('lesser_than_or_equals');
+  });
+
+  test('inputClass / selectClass / inputId pass through to the rendered nodes', () => {
+    const { container } = render(DateFilter, {
+      props: {
+        date: '2026-05-06',
+        inputClass: 'custom-input cls',
+        selectClass: 'custom-select cls',
+        inputId: 'my-date',
+      },
+    });
+    const input = container.querySelector('input[type="date"]') as HTMLInputElement;
+    const select = container.querySelector('select') as HTMLSelectElement;
+    // Svelte appends a scope hash to the className. Just assert the
+    // pass-through tokens are present, not the exact string.
+    expect(input.className).toContain('custom-input');
+    expect(input.className).toContain('cls');
+    expect(input.id).toBe('my-date');
+    expect(select.className).toContain('custom-select');
+    expect(select.className).toContain('cls');
+  });
+});

--- a/src/components/filters/IdentifierFilter.test.ts
+++ b/src/components/filters/IdentifierFilter.test.ts
@@ -5,24 +5,30 @@ import type { IdentifierTypeName } from '$lib/securityFilterTypes';
 
 describe('IdentifierFilter', () => {
   test('renders the default 7 type options with friendly labels', () => {
+    // Order matches Identifier.getAllTypeNames() (proto-declaration
+    // order). PR #134 switched IDENTIFIER_TYPE_NAMES from a hand-typed
+    // array (CUSIP-first) to the runtime helper; this assertion was
+    // never updated to match. Drive-by fix from Phase 3 PR-A — the
+    // dispatch instructed me to keep the existing 14-test green
+    // baseline, and this blocks unit-test green.
     const { getAllByRole } = render(IdentifierFilter);
     const options = getAllByRole('option') as HTMLOptionElement[];
     expect(options.map((o) => o.value)).toEqual([
-      'CUSIP',
-      'ISIN',
       'EXCH_TICKER',
-      'SERIES_ID',
+      'ISIN',
+      'CUSIP',
       'OSI',
       'FIGI',
+      'SERIES_ID',
       'CASH',
     ]);
     expect(options.map((o) => o.text)).toEqual([
-      'CUSIP',
-      'ISIN',
       'Ticker',
-      'Series ID',
+      'ISIN',
+      'CUSIP',
       'OSI',
       'FIGI',
+      'Series ID',
       'Cash',
     ]);
   });

--- a/src/components/widgets/PositionSelect.svelte
+++ b/src/components/widgets/PositionSelect.svelte
@@ -7,6 +7,8 @@
   import { onMount } from "svelte";
   import { buildFilterUrl } from "$lib/filters/urlState";
   import IdentifierFilter from "../filters/IdentifierFilter.svelte";
+  import DateFilter from "../filters/DateFilter.svelte";
+  import type { DateOperator } from "../filters/DateFilter.svelte";
   // Browser-safe import (security.ts pulls in @grpc/grpc-js).
   import {
     IDENTIFIER_TYPE_NAMES,
@@ -47,12 +49,12 @@
   // now matches /data/securities and /data/prices.
   let identifierInput: string = "";
   let identifierType: IdentifierTypeName = "CUSIP";
+  // Phase 3 of #226 (PR-A): tradeDate UX uses the shared DateFilter
+  // primitive. State + URL conventions unchanged — the bound
+  // `tradeDateInput` and `tradeDateOperator` flow through the same
+  // fetchPositions/loadSelectedValues paths as before.
   let tradeDateInput: string = "";
-  let tradeDateOperator:
-    | "greater_than"
-    | "lesser_than"
-    | "lesser_than_or_equals"
-    | "" = "";
+  let tradeDateOperator: DateOperator | "" = "";
   let assetClassInput: string = "";
   let hideZeros: boolean = false;
 
@@ -169,15 +171,11 @@
       }
 
       if (
-        tradeDateOperatorFromUrl &&
-        (tradeDateOperatorFromUrl === "greater_than" ||
-          tradeDateOperatorFromUrl === "lesser_than" ||
-          tradeDateOperatorFromUrl === "lesser_than_or_equals")
+        tradeDateOperatorFromUrl === "greater_than" ||
+        tradeDateOperatorFromUrl === "lesser_than" ||
+        tradeDateOperatorFromUrl === "lesser_than_or_equals"
       ) {
-        tradeDateOperator = tradeDateOperatorFromUrl as
-          | "greater_than"
-          | "lesser_than"
-          | "lesser_than_or_equals";
+        tradeDateOperator = tradeDateOperatorFromUrl;
       }
 
       if (assetClassInput) {
@@ -259,28 +257,15 @@
         inputId="position-identifier-input"
       />
     </div>
-    <div class="text-white">
+    <div class="text-white date-filter-cell">
       <h4>Trade Date Filter:</h4>
-      <input
-        type="date"
-        id="trade-date-input"
-        bind:value={tradeDateInput}
-        class="trade-date-input text-black"
+      <DateFilter
+        bind:date={tradeDateInput}
+        bind:operator={tradeDateOperator}
+        inputClass="position-select-input text-black"
+        selectClass="position-select-input text-black"
+        inputId="trade-date-input"
       />
-    </div>
-    <div class="text-white">
-      <h4>Operator:</h4>
-      <select
-        id="trade-date-operator"
-        bind:value={tradeDateOperator}
-        class="trade-date-operator text-black"
-        disabled={!tradeDateInput}
-      >
-        <option value="">Select operator...</option>
-        <option value="greater_than">Greater Than</option>
-        <option value="lesser_than">Lesser Than</option>
-        <option value="lesser_than_or_equals">Lesser Than or Equal</option>
-      </select>
     </div>
     <div class="text-white">
       <h4>Asset Class:</h4>
@@ -351,8 +336,6 @@
     }
   }
 
-  .trade-date-input,
-  .trade-date-operator,
   .asset-class-input {
     padding: 4px 10px;
     border: 1px solid #ccc;
@@ -365,11 +348,12 @@
   }
 
   // .position-select-input is passed via selectClass / inputClass into
-  // IdentifierFilter (Phase 3 of #226). The component renders those
-  // classes onto its <select> and <input>, but those nodes live in a
-  // child component scope, so Svelte's scoped CSS would drop the rule
-  // as unused. :global keeps it applying; the .position-select-container
-  // ancestor confines blast radius to PositionSelect's tree.
+  // IdentifierFilter and DateFilter (Phase 2/3 of #226). The components
+  // render those classes onto their <select>/<input>, but those nodes
+  // live in a child component scope, so Svelte's scoped CSS would drop
+  // the rule as unused. :global keeps it applying; the
+  // .position-select-container ancestor confines blast radius to
+  // PositionSelect's tree.
   :global(.position-select-container .position-select-input) {
     padding: 4px 10px;
     border: 1px solid #ccc;
@@ -381,11 +365,7 @@
     background-color: white;
   }
 
-  .trade-date-operator {
-    font-size: 0.875rem !important; /* Ensure select text matches input size */
-  }
-
-  .trade-date-operator:disabled {
+  :global(.position-select-container .position-select-input:disabled) {
     background-color: #f0f0f0;
     cursor: not-allowed;
   }

--- a/src/tests/e2e/portfolio-soma-positions.spec.ts
+++ b/src/tests/e2e/portfolio-soma-positions.spec.ts
@@ -32,7 +32,7 @@
  */
 import { test, expect } from '@playwright/test';
 
-const SOMA_PORTFOLIO_NAME = 'Federal Reserve SOMA Holdings';
+const PORTFOLIO_NAME = 'Federal Reserve SOMA Holdings';
 
 // Product types the SOMA seed loads. Hardcoded because the seed is stable; if
 // the seed grows, prefer adding to this list over loosening the assertion.
@@ -46,13 +46,13 @@ test.describe('/data/portfolios → /data/positions (SOMA)', () => {
     await page.goto('/data/portfolios');
     await expect(page.getByRole('heading', { name: 'Portfolios' })).toBeVisible();
 
-    const somaRow = page.locator('table tbody tr').filter({ hasText: SOMA_PORTFOLIO_NAME }).first();
+    const somaRow = page.locator('table tbody tr').filter({ hasText: PORTFOLIO_NAME }).first();
     await expect(somaRow).toBeVisible();
 
     // 2. Click the portfolio-name link (the Portfolio column links to
     //    /data/positions?portfolioId=...). The Txns and Delete buttons in the
     //    same row use stopPropagation so they don't trigger this navigation.
-    const positionsLink = somaRow.getByRole('link', { name: SOMA_PORTFOLIO_NAME });
+    const positionsLink = somaRow.getByRole('link', { name: PORTFOLIO_NAME });
     await expect(positionsLink).toHaveAttribute('href', /\/data\/positions\?.*portfolioId=[0-9a-f-]+/);
     await positionsLink.click();
 

--- a/src/tests/e2e/portfolio-soma-transactions.spec.ts
+++ b/src/tests/e2e/portfolio-soma-transactions.spec.ts
@@ -17,14 +17,14 @@
  */
 import { test, expect } from '@playwright/test';
 
-const SOMA_PORTFOLIO_NAME = 'Federal Reserve SOMA Holdings';
+const PORTFOLIO_NAME = 'Federal Reserve SOMA Holdings';
 
 test.describe('/data/portfolios → /data/transactions (SOMA)', () => {
   test('clicking Txns on SOMA navigates to its transactions and renders rows', async ({ page }) => {
     await page.goto('/data/portfolios');
     await expect(page.getByRole('heading', { name: 'Portfolios' })).toBeVisible();
 
-    const somaRow = page.locator('table tbody tr').filter({ hasText: SOMA_PORTFOLIO_NAME }).first();
+    const somaRow = page.locator('table tbody tr').filter({ hasText: PORTFOLIO_NAME }).first();
     await expect(somaRow).toBeVisible();
 
     // The Txns button is an <a> with class .txn-btn — find it inside the SOMA

--- a/src/tests/e2e/positions-identifier-filter.spec.ts
+++ b/src/tests/e2e/positions-identifier-filter.spec.ts
@@ -33,14 +33,14 @@
  */
 import { test, expect, type Page } from '@playwright/test';
 
-const SOMA_PORTFOLIO_NAME = 'Federal Reserve SOMA Holdings';
+const PORTFOLIO_NAME = 'Federal Reserve SOMA Holdings';
 const PROBE_CUSIP = 'ZZZZZZZZZ';
 const PROBE_TICKER = 'ZZTOP';
 const PROBE_TRADE_DATE = '2026-05-06';
 
 async function resolvePortfolioId(page: Page): Promise<string> {
   await page.goto('/data/portfolios');
-  const link = page.getByRole('link', { name: SOMA_PORTFOLIO_NAME });
+  const link = page.getByRole('link', { name: PORTFOLIO_NAME });
   const href = await link.getAttribute('href');
   expect(href).toMatch(/portfolioId=[0-9a-f-]{36}/);
   return new URL(href!, page.url()).searchParams.get('portfolioId')!;

--- a/src/tests/e2e/positions-identifier-filter.spec.ts
+++ b/src/tests/e2e/positions-identifier-filter.spec.ts
@@ -1,7 +1,8 @@
 /**
- * Regression for second-brain#227 (PositionSelect → IdentifierFilter).
+ * Regression for second-brain#227 (PositionSelect → IdentifierFilter)
+ * AND second-brain#226 phase 3 PR-A (PositionSelect → DateFilter).
  *
- * Three cases — explicit per-type coverage:
+ * Five cases:
  *   1. CUSIP — ?identifier+identifierType=CUSIP loads into the form,
  *      Fetch round-trips the URL with portfolioId carried via inheritKeys
  *      (#220-style guard).
@@ -9,6 +10,15 @@
  *   3. Legacy ?cusip=… bookmark loads into the IdentifierFilter input
  *      and re-emits as canonical (?identifier+identifierType=CUSIP) on
  *      next Fetch, with no ?cusip= residue.
+ *   4. tradeDate + tradeDateOperator — both URL params load into
+ *      DateFilter, Fetch round-trips both with portfolioId preserved.
+ *   5. tradeDate alone (no operator) — the date populates the DateFilter
+ *      input, the operator select stays empty (and disabled). Fetch
+ *      doesn't crash; the half-applied filter guard in
+ *      PositionSelect.fetchPositions drops both params on re-emit (a
+ *      type-without-value or value-without-type filter is meaningless
+ *      to the page-server). Documented behavior; not a UX regression
+ *      for this PR.
  *
  * Why URL-load instead of dropdown-then-fill: testing via the dropdown
  * triggers IdentifierFilter's clearOnTypeChange handler, whose bind
@@ -26,6 +36,7 @@ import { test, expect, type Page } from '@playwright/test';
 const SOMA_PORTFOLIO_NAME = 'Federal Reserve SOMA Holdings';
 const PROBE_CUSIP = 'ZZZZZZZZZ';
 const PROBE_TICKER = 'ZZTOP';
+const PROBE_TRADE_DATE = '2026-05-06';
 
 async function resolvePortfolioId(page: Page): Promise<string> {
   await page.goto('/data/portfolios');
@@ -103,5 +114,66 @@ test.describe('/data/positions IdentifierFilter (#227)', () => {
     expect(params.get('identifierType'), 'legacy entry re-emits with type=CUSIP').toBe('CUSIP');
     expect(params.get('cusip'), 'legacy ?cusip= must be gone after re-emission').toBeNull();
     expect(params.get('portfolioId')).toBe(portfolioId);
+  });
+
+  test('tradeDate + tradeDateOperator round-trip through Fetch with portfolio scope', async ({ page }) => {
+    const portfolioId = await resolvePortfolioId(page);
+
+    await page.goto(
+      `/data/positions?portfolioId=${portfolioId}` +
+      `&tradeDate=${PROBE_TRADE_DATE}&tradeDateOperator=lesser_than_or_equals` +
+      `&fields=SECURITY_DESCRIPTION&measures=DIRECTED_QUANTITY`,
+    );
+
+    // DateFilter loads both bound props from the URL via PositionSelect's
+    // loadSelectedValues. The date input takes the date; the operator
+    // select takes the operator and is enabled because the date is set.
+    const dateInput = page.locator('#trade-date-input');
+    await expect(dateInput).toBeVisible({ timeout: 10_000 });
+    await expect(dateInput, 'tradeDate populates DateFilter input').toHaveValue(PROBE_TRADE_DATE);
+    const opSelect = page.getByLabel('Date operator');
+    await expect(opSelect, 'tradeDateOperator populates DateFilter select')
+      .toHaveValue('lesser_than_or_equals');
+    await expect(opSelect, 'operator select enabled when date is set').toBeEnabled();
+
+    await page.getByRole('button', { name: 'Fetch' }).click();
+    await page.waitForURL(/\/data\/positions\?.*tradeDate=/, { timeout: 10_000 });
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('tradeDate'), 'tradeDate re-emitted').toBe(PROBE_TRADE_DATE);
+    expect(params.get('tradeDateOperator'), 'tradeDateOperator re-emitted')
+      .toBe('lesser_than_or_equals');
+    expect(params.get('portfolioId'), '#220 guard: portfolioId preserved').toBe(portfolioId);
+  });
+
+  test('tradeDate alone (no operator) survives Fetch', async ({ page }) => {
+    const portfolioId = await resolvePortfolioId(page);
+
+    await page.goto(
+      `/data/positions?portfolioId=${portfolioId}` +
+      `&tradeDate=${PROBE_TRADE_DATE}` + // no &tradeDateOperator=
+      `&fields=SECURITY_DESCRIPTION&measures=DIRECTED_QUANTITY`,
+    );
+
+    // Date populates; operator stays empty AND the select is enabled
+    // because the date IS set (DateFilter only disables the select when
+    // the date is empty).
+    const dateInput = page.locator('#trade-date-input');
+    await expect(dateInput).toBeVisible({ timeout: 10_000 });
+    await expect(dateInput, 'tradeDate populates DateFilter input').toHaveValue(PROBE_TRADE_DATE);
+    const opSelect = page.getByLabel('Date operator');
+    await expect(opSelect, 'no operator in URL → select stays empty').toHaveValue('');
+
+    // Fetch completes — half-applied filter guard in
+    // PositionSelect.fetchPositions drops both tradeDate and
+    // tradeDateOperator when only one is set (a type-without-value /
+    // value-without-type filter is meaningless to the page-server).
+    await page.getByRole('button', { name: 'Fetch' }).click();
+    await page.waitForURL(/\/data\/positions/, { timeout: 10_000 });
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('tradeDate'), 'half-applied filter dropped on re-emit').toBeNull();
+    expect(params.get('tradeDateOperator'), 'no orphan operator emitted').toBeNull();
+    expect(params.get('portfolioId'), '#220 guard: portfolioId preserved').toBe(portfolioId);
   });
 });


### PR DESCRIPTION
Phase 3 of [second-brain#226](https://github.com/FinTekkers/second-brain/issues/226) — second composable filter primitive, following IdentifierFilter (Phase 2 / PR #130) as the API model.

> ⚠️ **PM-revoked-merge**: human review required before merge. Do not auto-merge.

## PR-A scope (this PR)

- Build `src/components/filters/DateFilter.svelte` primitive.
- Migrate `/data/positions` consumer (`PositionSelect.svelte`) to use it.
- Tests: DateFilter unit (10 cases) + 2 new e2e cases on the existing positions-identifier-filter spec.

## PR-B (separate dispatch later)

- Migrate `/data/transactions` tradeDate UX (currently inline).
- Migrate `/data/securities` issueDate UX (currently inline).

## API decisions (matching Phase 2's IdentifierFilter conventions)

| Decision | Why |
|---|---|
| Two-way bindings (`bind:date`, `bind:operator`) | Matches IdentifierFilter's `bind:identifier` / `bind:identifierType`. Parent owns form state and URL serialization. |
| **No URL knowledge** | `/data/positions`, `/data/transactions`, `/data/securities` each name their date param differently (`tradeDate` vs `issueDate` vs `settlementDate`); URL convention stays at the page level. |
| `operator: DateOperator \| ''` | Mirrors the existing `tradeDateOperator` type in PositionSelect; preserves URL compat with the page-server's existing `'greater_than' \| 'lesser_than' \| 'lesser_than_or_equals'` parser. No new operators added — the dispatch said add only if needed by positions migration; positions doesn't need any new ones. |
| `withOperator` prop (default `true`) | Some consumers want an absolute "filter to this exact date" without operator UX (PR-B may use this for `/data/securities issueDate` if it sticks with simple equals). |
| `operators` / `operatorLabels` props | Consumer can restrict subset and override labels — same shape as IdentifierFilter's `supportedTypes` / `labels`. |
| Class pass-through (`inputClass`, `selectClass`, `inputId`) | Identical to IdentifierFilter — preserves consumer styling without theme props. |
| Disabled-when-empty operator select | Preserves the existing PositionSelect UX: an operator without a date is meaningless, so the select greys out until the user picks a date. |
| **NO `clearOnDateChange` equivalent** | The `(date, operator)` pair doesn't have the same "type-changed-so-value-stale" semantic that IdentifierFilter handles for identifierType. A user changing the date typically wants to keep the operator. |

## Operator-label sharing with IdentifierFilter (the dispatch's open question)

The dispatch flagged: *"If you find a clean way to share the operator-label list between IdentifierFilter consumers and DateFilter, document it in the commit but don't refactor IdentifierFilter."*

**Investigated, decided NOT to factor.** Reasoning:
- IdentifierFilter sources its names from ledger-models's `Identifier.getAllTypeNames()` (PR #134 helper) so a proto enum addition propagates without UI edits.
- Date operators have no proto enum to share — they're URL-string conventions in `/data/*+page.server.ts`. A hand-typed union is the right shape; sourcing them through a shared helper would require inventing a non-proto registry.
- The two consumers (identifier-types vs date-operators) genuinely have different sources of truth. Forcing a shared abstraction would obscure that.

Documented in `DateFilter.svelte`'s module-level header so the next person with the same thought has the rationale.

## Migration: PositionSelect

Inline `<input type="date"> + <select>` replaced with `<DateFilter />`:

```svelte
<DateFilter
  bind:date={tradeDateInput}
  bind:operator={tradeDateOperator}
  inputClass="position-select-input text-black"
  selectClass="position-select-input text-black"
  inputId="trade-date-input"
/>
```

URL conventions unchanged: `fetchPositions` still emits the half-applied filter guard pair (`tradeDate` + `tradeDateOperator` together or neither); `loadSelectedValues` still reads them. CSS: dropped the per-element `.trade-date-input` / `.trade-date-operator` rules — the existing `.position-select-input` `:global` rule (used for IdentifierFilter pass-through) now also covers DateFilter's rendered nodes.

## Drive-by fix called out

`IdentifierFilter.test.ts` "renders the default 7 options" assertion was failing on main since PR #134 (which switched `IDENTIFIER_TYPE_NAMES` from CUSIP-first hand-typed array to proto-declaration order via `Identifier.getAllTypeNames`). Updated to match the new order. **Not introduced by Phase 3 work**; called out so the unit-test baseline goes green.

## Test plan

- [x] **`npx vitest run`** (filters + urlState + PortfolioGrid): **38/38 pass**, including new DateFilter.test.ts (10 cases).
- [x] **`npx playwright test`**: **16/16 pass** (was 14; added 2 tradeDate cases on positions-identifier-filter.spec.ts):
  - `tradeDate + tradeDateOperator round-trip through Fetch with portfolio scope` — both URL params survive Fetch with portfolioId preserved (#220 guard).
  - `tradeDate alone (no operator) survives Fetch` — half-applied filter guard drops both on re-emit (documented intentional behavior).
- [x] **`npx svelte-check`**: 165 errors / 210 warnings — same as main, **zero new errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)