### PR TITLE
SecurityTypeFilter + AssetClassFilter primitives + /data/securities migration (Phase 3 of #226)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@auth/core": "^0.27.0",
 				"@auth/sveltekit": "^0.13.0",
-				"@fintekkers/ledger-models": "^0.1.133",
+				"@fintekkers/ledger-models": "^0.1.134",
 				"@iconify-json/mdi": "^1.2.3",
 				"@iconify-json/ph": "^1.2.2",
 				"@lucia-auth/adapter-drizzle": "^1.0.7",
@@ -2528,9 +2528,9 @@
 			}
 		},
 		"node_modules/@fintekkers/ledger-models": {
-			"version": "0.1.133",
-			"resolved": "https://registry.npmjs.org/@fintekkers/ledger-models/-/ledger-models-0.1.133.tgz",
-			"integrity": "sha512-uMiVgoRKfVnXGfi/t9fPQaGxgW9FO5sCw7Av/BNNniknr4T/WEWkaMpEYlLmTtqPFUF11B0bk41ap8Mmh2TwBQ==",
+			"version": "0.1.134",
+			"resolved": "https://registry.npmjs.org/@fintekkers/ledger-models/-/ledger-models-0.1.134.tgz",
+			"integrity": "sha512-OVDCDVgLNdKBwWi81aMUMUUM57z66oV2a3mJHDkDUji8gXImqU3x2jjqQq8OlBJqBEgmht8X912OC1g296pPOw==",
 			"license": "ISC",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.8.18",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"@auth/core": "^0.27.0",
 		"@auth/sveltekit": "^0.13.0",
-		"@fintekkers/ledger-models": "^0.1.133",
+		"@fintekkers/ledger-models": "^0.1.134",
 		"@iconify-json/mdi": "^1.2.3",
 		"@iconify-json/ph": "^1.2.2",
 		"@lucia-auth/adapter-drizzle": "^1.0.7",

--- a/src/components/filters/AssetClassFilter.svelte
+++ b/src/components/filters/AssetClassFilter.svelte
@@ -1,0 +1,64 @@
+<script lang="ts" context="module">
+  /**
+   * Friendly default labels for AssetClass enum entries.
+   *
+   * `CASH_ASSET_CLASS` is the proto name due to a package-wide enum
+   * collision with `IdentifierTypeProto.CASH` — the friendly 'Cash'
+   * label hides the wart from end users while the URL/proto still
+   * carries the canonical name (?assetClass=CASH_ASSET_CLASS).
+   *
+   * Consumers can override per-entry via the `labels` prop.
+   */
+  import type { AssetClassName } from '$lib/securityFilterTypes';
+
+  export const DEFAULT_LABELS: Record<AssetClassName, string> = {
+    FIXED_INCOME: 'Fixed Income',
+    EQUITY: 'Equity',
+    CASH_ASSET_CLASS: 'Cash',
+    INDEX: 'Index',
+  };
+</script>
+
+<script lang="ts">
+  /**
+   * Phase 3 of second-brain#226 — fourth composable filter primitive.
+   * Same shape as SecurityTypeFilter / IdentifierFilter / DateFilter:
+   *   - Two-way bound state (bind:value).
+   *   - No URL knowledge — parent owns serialization.
+   *   - Class pass-through (selectClass).
+   *   - supportedTypes / labels props for subset + override.
+   *
+   * Owns: a single proto-name dropdown for AssetClass. Includes an
+   * "All" empty option for the "no filter" case.
+   *
+   * Phased note (per dispatch): the proto field on Security is still a
+   * free-form string — this filter normalizes the UI side to emit the
+   * enum name (e.g. 'FIXED_INCOME') as the assetClass URL param value.
+   * Backend can match the string OR free-form values; no backend change
+   * required for this PR.
+   */
+  // AssetClassName type is already imported in <script context="module">
+  // above and shared with this instance script.
+  import { ASSET_CLASS_NAMES } from '$lib/securityFilterTypes';
+
+  export let value: AssetClassName | '' = '';
+  export let supportedTypes: readonly AssetClassName[] = ASSET_CLASS_NAMES;
+  export let labels: Partial<Record<AssetClassName, string>> = {};
+  export let selectClass: string = '';
+  export let selectId: string = 'asset-class-filter-value';
+  export let allLabel: string = 'All';
+
+  $: resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+</script>
+
+<select
+  id={selectId}
+  class={selectClass}
+  bind:value
+  aria-label="Asset class"
+>
+  <option value="">{allLabel}</option>
+  {#each supportedTypes as t}
+    <option value={t}>{resolvedLabels[t]}</option>
+  {/each}
+</select>

--- a/src/components/filters/AssetClassFilter.svelte
+++ b/src/components/filters/AssetClassFilter.svelte
@@ -1,24 +1,3 @@
-<script lang="ts" context="module">
-  /**
-   * Friendly default labels for AssetClass enum entries.
-   *
-   * `CASH_ASSET_CLASS` is the proto name due to a package-wide enum
-   * collision with `IdentifierTypeProto.CASH` — the friendly 'Cash'
-   * label hides the wart from end users while the URL/proto still
-   * carries the canonical name (?assetClass=CASH_ASSET_CLASS).
-   *
-   * Consumers can override per-entry via the `labels` prop.
-   */
-  import type { AssetClassName } from '$lib/securityFilterTypes';
-
-  export const DEFAULT_LABELS: Record<AssetClassName, string> = {
-    FIXED_INCOME: 'Fixed Income',
-    EQUITY: 'Equity',
-    CASH_ASSET_CLASS: 'Cash',
-    INDEX: 'Index',
-  };
-</script>
-
 <script lang="ts">
   /**
    * Phase 3 of second-brain#226 — fourth composable filter primitive.
@@ -36,10 +15,17 @@
    * enum name (e.g. 'FIXED_INCOME') as the assetClass URL param value.
    * Backend can match the string OR free-form values; no backend change
    * required for this PR.
+   *
+   * Friendly default labels (e.g. CASH_ASSET_CLASS → 'Cash') live in
+   * $lib/securityFilterTypes — single source for the proto-enum
+   * vocabulary; the friendly label hides the CASH_ASSET_CLASS naming
+   * wart (collision with IdentifierTypeProto.CASH) from end users.
    */
-  // AssetClassName type is already imported in <script context="module">
-  // above and shared with this instance script.
-  import { ASSET_CLASS_NAMES } from '$lib/securityFilterTypes';
+  import {
+    ASSET_CLASS_NAMES,
+    ASSET_CLASS_LABELS,
+    type AssetClassName,
+  } from '$lib/securityFilterTypes';
 
   export let value: AssetClassName | '' = '';
   export let supportedTypes: readonly AssetClassName[] = ASSET_CLASS_NAMES;
@@ -48,7 +34,7 @@
   export let selectId: string = 'asset-class-filter-value';
   export let allLabel: string = 'All';
 
-  $: resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  $: resolvedLabels = { ...ASSET_CLASS_LABELS, ...labels };
 </script>
 
 <select

--- a/src/components/filters/IdentifierFilter.svelte
+++ b/src/components/filters/IdentifierFilter.svelte
@@ -26,6 +26,8 @@
   import { createEventDispatcher } from 'svelte';
   import {
     IDENTIFIER_TYPE_NAMES,
+    IDENTIFIER_TYPE_LABELS,
+    IDENTIFIER_TYPE_PLACEHOLDERS,
     type IdentifierTypeName,
   } from '$lib/securityFilterTypes';
 
@@ -38,30 +40,9 @@
   // passes the full list (or omits this prop).
   export let supportedTypes: readonly IdentifierTypeName[] = IDENTIFIER_TYPE_NAMES;
 
-  // Built-in human-friendly labels. Consumers can override per-type via the
-  // `labels` prop (merged over defaults). Phase 1 SecuritySelect was using
-  // raw proto names — Phase 2 standardizes on these prettier ones, but a
-  // consumer that wants raw names can pass a labels override.
-  const DEFAULT_LABELS: Record<IdentifierTypeName, string> = {
-    CUSIP: 'CUSIP',
-    ISIN: 'ISIN',
-    EXCH_TICKER: 'Ticker',
-    SERIES_ID: 'Series ID',
-    OSI: 'OSI',
-    FIGI: 'FIGI',
-    CASH: 'Cash',
-  };
-
-  const DEFAULT_PLACEHOLDERS: Record<IdentifierTypeName, string> = {
-    CUSIP: 'e.g. 912828ZT0',
-    ISIN: 'e.g. GB0002404557',
-    EXCH_TICKER: 'e.g. AAPL',
-    SERIES_ID: 'e.g. CPIAUCSL',
-    OSI: 'e.g. AAPL  240119C00150000',
-    FIGI: 'e.g. BBG000B9XRY4',
-    CASH: 'e.g. USD',
-  };
-
+  // Built-in human-friendly labels + per-type placeholder hints. Defaults
+  // live in $lib/securityFilterTypes (single source for the proto-enum
+  // vocabulary); consumers can override per-type via the props below.
   export let labels: Partial<Record<IdentifierTypeName, string>> = {};
   export let placeholders: Partial<Record<IdentifierTypeName, string>> = {};
 
@@ -79,8 +60,8 @@
   export let selectClass: string = '';
   export let inputId: string = 'identifier-filter-value';
 
-  $: resolvedLabels = { ...DEFAULT_LABELS, ...labels };
-  $: resolvedPlaceholders = { ...DEFAULT_PLACEHOLDERS, ...placeholders };
+  $: resolvedLabels = { ...IDENTIFIER_TYPE_LABELS, ...labels };
+  $: resolvedPlaceholders = { ...IDENTIFIER_TYPE_PLACEHOLDERS, ...placeholders };
   $: currentPlaceholder = resolvedPlaceholders[identifierType];
 
   const dispatch = createEventDispatcher<{ typeChange: IdentifierTypeName }>();

--- a/src/components/filters/SecurityTypeFilter.svelte
+++ b/src/components/filters/SecurityTypeFilter.svelte
@@ -1,0 +1,75 @@
+<script lang="ts" context="module">
+  /**
+   * Friendly default labels for SecurityType enum entries. Hides the
+   * `_SECURITY` suffix on the user-facing dropdown while the URL/proto
+   * still carries the canonical name (e.g. ?securityType=BOND_SECURITY).
+   * Consumers can override per-entry via the `labels` prop.
+   *
+   * Adding a new SecurityTypeProto enum entry lights up automatically in
+   * the dropdown via SecurityType.getAllTypeNames() — but it'll display
+   * its raw proto name until added here. Treated as a deliberate review
+   * hook (same as the IdentifierTypeName literal-union lag).
+   */
+  import type { SecurityTypeName } from '$lib/securityFilterTypes';
+
+  export const DEFAULT_LABELS: Record<SecurityTypeName, string> = {
+    BOND_SECURITY: 'Bond',
+    EQUITY_SECURITY: 'Equity',
+    INDEX_SECURITY: 'Index',
+    CASH_SECURITY: 'Cash',
+    TIPS: 'TIPS',
+    FRN: 'FRN',
+    FX_SPOT: 'FX Spot',
+    EQUITY_INDEX_SECURITY: 'Equity Index',
+  };
+</script>
+
+<script lang="ts">
+  /**
+   * Phase 3 of second-brain#226 — third composable filter primitive,
+   * matching IdentifierFilter / DateFilter conventions:
+   *   - Two-way bound state (bind:value).
+   *   - No URL knowledge — parent owns serialization.
+   *   - Class pass-through (selectClass) for consumer styling.
+   *   - supportedTypes / labels props for subset + override.
+   *
+   * Owns: a single proto-name dropdown for SecurityType. Includes an
+   * "All" empty option so consumers can express "no filter" by emitting
+   * an empty string.
+   */
+  // SecurityTypeName type is already imported in <script context="module">
+  // above and shared with this instance script.
+  import { SECURITY_TYPE_NAMES } from '$lib/securityFilterTypes';
+
+  // Two-way binding — empty string represents "no filter" / All.
+  export let value: SecurityTypeName | '' = '';
+
+  // Subset of proto names the consumer wants. Default = full set from
+  // SecurityType.getAllTypeNames().
+  export let supportedTypes: readonly SecurityTypeName[] = SECURITY_TYPE_NAMES;
+
+  // Per-entry label override; merged over DEFAULT_LABELS.
+  export let labels: Partial<Record<SecurityTypeName, string>> = {};
+
+  // Class pass-through (matches IdentifierFilter / DateFilter).
+  export let selectClass: string = '';
+  export let selectId: string = 'security-type-filter-value';
+
+  // Empty-option label. Consumers wanting strict "must pick a type" UX
+  // can pass `allLabel=''` and constrain via the parent.
+  export let allLabel: string = 'All';
+
+  $: resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+</script>
+
+<select
+  id={selectId}
+  class={selectClass}
+  bind:value
+  aria-label="Security type"
+>
+  <option value="">{allLabel}</option>
+  {#each supportedTypes as t}
+    <option value={t}>{resolvedLabels[t]}</option>
+  {/each}
+</select>

--- a/src/components/filters/SecurityTypeFilter.svelte
+++ b/src/components/filters/SecurityTypeFilter.svelte
@@ -1,29 +1,3 @@
-<script lang="ts" context="module">
-  /**
-   * Friendly default labels for SecurityType enum entries. Hides the
-   * `_SECURITY` suffix on the user-facing dropdown while the URL/proto
-   * still carries the canonical name (e.g. ?securityType=BOND_SECURITY).
-   * Consumers can override per-entry via the `labels` prop.
-   *
-   * Adding a new SecurityTypeProto enum entry lights up automatically in
-   * the dropdown via SecurityType.getAllTypeNames() — but it'll display
-   * its raw proto name until added here. Treated as a deliberate review
-   * hook (same as the IdentifierTypeName literal-union lag).
-   */
-  import type { SecurityTypeName } from '$lib/securityFilterTypes';
-
-  export const DEFAULT_LABELS: Record<SecurityTypeName, string> = {
-    BOND_SECURITY: 'Bond',
-    EQUITY_SECURITY: 'Equity',
-    INDEX_SECURITY: 'Index',
-    CASH_SECURITY: 'Cash',
-    TIPS: 'TIPS',
-    FRN: 'FRN',
-    FX_SPOT: 'FX Spot',
-    EQUITY_INDEX_SECURITY: 'Equity Index',
-  };
-</script>
-
 <script lang="ts">
   /**
    * Phase 3 of second-brain#226 — third composable filter primitive,
@@ -36,10 +10,19 @@
    * Owns: a single proto-name dropdown for SecurityType. Includes an
    * "All" empty option so consumers can express "no filter" by emitting
    * an empty string.
+   *
+   * Friendly default labels (e.g. BOND_SECURITY → 'Bond') live in
+   * $lib/securityFilterTypes alongside the runtime name list — single
+   * source for the proto-enum vocabulary. Adding a new SecurityTypeProto
+   * enum entry lights up the dropdown via SecurityType.getAllTypeNames()
+   * automatically; the raw proto name displays until a label is added —
+   * deliberate review hook.
    */
-  // SecurityTypeName type is already imported in <script context="module">
-  // above and shared with this instance script.
-  import { SECURITY_TYPE_NAMES } from '$lib/securityFilterTypes';
+  import {
+    SECURITY_TYPE_NAMES,
+    SECURITY_TYPE_LABELS,
+    type SecurityTypeName,
+  } from '$lib/securityFilterTypes';
 
   // Two-way binding — empty string represents "no filter" / All.
   export let value: SecurityTypeName | '' = '';
@@ -48,7 +31,7 @@
   // SecurityType.getAllTypeNames().
   export let supportedTypes: readonly SecurityTypeName[] = SECURITY_TYPE_NAMES;
 
-  // Per-entry label override; merged over DEFAULT_LABELS.
+  // Per-entry label override; merged over the centralized SECURITY_TYPE_LABELS.
   export let labels: Partial<Record<SecurityTypeName, string>> = {};
 
   // Class pass-through (matches IdentifierFilter / DateFilter).
@@ -59,7 +42,7 @@
   // can pass `allLabel=''` and constrain via the parent.
   export let allLabel: string = 'All';
 
-  $: resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  $: resolvedLabels = { ...SECURITY_TYPE_LABELS, ...labels };
 </script>
 
 <select

--- a/src/components/widgets/SecuritySelect.svelte
+++ b/src/components/widgets/SecuritySelect.svelte
@@ -5,22 +5,40 @@
   // in the client bundle).
   import {
     SECURITY_TYPE_NAMES,
+    ASSET_CLASS_NAMES,
     type IdentifierTypeName,
     type SecurityTypeName,
+    type AssetClassName,
   } from "$lib/securityFilterTypes";
   import IdentifierFilter from "../filters/IdentifierFilter.svelte";
+  import SecurityTypeFilter from "../filters/SecurityTypeFilter.svelte";
+  import AssetClassFilter from "../filters/AssetClassFilter.svelte";
 
-  // Phase 2 of second-brain#226: identifier-type dropdown + value input
-  // moved into the IdentifierFilter primitive. Phase 1's inline 7-option
-  // dropdown + per-type placeholder logic now lives in
-  // src/components/filters/IdentifierFilter.svelte and is shared with
-  // /data/prices.
+  // Phase 2/3 of second-brain#226: filter primitives now own their controls.
+  // - Phase 2 (PR #130): identifier-type dropdown + value → IdentifierFilter.
+  // - Phase 3 (this PR): assetClass <input> → AssetClassFilter; securityType
+  //   <select> → SecurityTypeFilter. Both emit proto-enum names via URL
+  //   (FIXED_INCOME / BOND_SECURITY / …); page-server still treats the
+  //   value as a free-form string so legacy URLs like ?assetClass=Equity
+  //   continue to filter correctly server-side.
+
+  // Legacy free-form → proto-enum normalization for assetClass URL load.
+  // Pre-Phase-3 URLs (e.g. tests using ?assetClass=Equity) carried free-
+  // form labels; this lets the dropdown round-trip them onto the
+  // canonical enum value so the user sees their filter selected and a
+  // subsequent Fetch re-emits the canonical shape.
+  const ASSET_CLASS_FREEFORM_TO_ENUM: Record<string, AssetClassName> = {
+    'fixed income': 'FIXED_INCOME',
+    'equity': 'EQUITY',
+    'cash': 'CASH_ASSET_CLASS',
+    'index': 'INDEX',
+  };
 
   let identifierInput: string = "";
   let identifierType: IdentifierTypeName = "CUSIP";
   let issueDateInput: string = "";
   let issueDateOperator: "greater_than" | "lesser_than" | "" = "";
-  let assetClassInput: string = "";
+  let assetClassInput: AssetClassName | "" = "";
   let issuerNameInput: string = "";
   let securityTypeInput: SecurityTypeName | "" = "";
 
@@ -46,7 +64,7 @@
         identifierType: trimmedIdentifier ? identifierType : undefined,
         issueDate: issueDateOverride,
         issueDateOperator: issueDateOperatorOverride,
-        assetClass: assetClassInput.trim() || undefined,
+        assetClass: assetClassInput || undefined,
         issuerName: issuerNameInput.trim() || undefined,
         securityType: securityTypeInput || undefined,
       },
@@ -89,7 +107,19 @@
     }
 
     const assetClassFromUrl = urlParams.get("assetClass");
-    if (assetClassFromUrl !== null) assetClassInput = assetClassFromUrl;
+    if (assetClassFromUrl !== null && assetClassFromUrl !== "") {
+      // Canonical: a proto-enum name (FIXED_INCOME, EQUITY, …).
+      if ((ASSET_CLASS_NAMES as readonly string[]).includes(assetClassFromUrl)) {
+        assetClassInput = assetClassFromUrl as AssetClassName;
+      } else {
+        // Legacy free-form (Equity, Fixed Income, …) — map to enum so
+        // the dropdown round-trips on the next Fetch. Falls through to
+        // empty if the value isn't recognized; the page-server still
+        // sees the original URL param and applies it as a string filter.
+        const normalized = ASSET_CLASS_FREEFORM_TO_ENUM[assetClassFromUrl.toLowerCase()];
+        if (normalized) assetClassInput = normalized;
+      }
+    }
 
     const issuerNameFromUrl = urlParams.get("issuerName");
     if (issuerNameFromUrl !== null) issuerNameInput = issuerNameFromUrl;
@@ -115,12 +145,10 @@
     </div>
     <div class="text-white">
       <h4>Asset Class:</h4>
-      <input
-        type="text"
-        id="asset-class-input"
-        placeholder="e.g. Fixed Income (blank = all)"
+      <AssetClassFilter
         bind:value={assetClassInput}
-        class="filter-input text-black"
+        selectClass="filter-select text-black"
+        selectId="asset-class-input"
       />
     </div>
     <div class="text-white">
@@ -135,16 +163,11 @@
     </div>
     <div class="text-white">
       <h4>Security Type:</h4>
-      <select
-        id="security-type-select"
+      <SecurityTypeFilter
         bind:value={securityTypeInput}
-        class="filter-select text-black"
-      >
-        <option value="">All</option>
-        {#each SECURITY_TYPE_NAMES as name}
-          <option value={name}>{name}</option>
-        {/each}
-      </select>
+        selectClass="filter-select text-black"
+        selectId="security-type-select"
+      />
     </div>
   </div>
   <div class="security-select-container flex flex-col sm:flex-row gap-2 mt-2">

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -8,6 +8,7 @@ import type BondSecurity from "@fintekkers/ledger-models/node/wrappers/models/se
 import { ZonedDateTime } from "@fintekkers/ledger-models/node/wrappers/models/utils/datetime";
 import { getServiceConnection } from "$lib/grpc-auth";
 import { SecurityTypeProto } from "@fintekkers/ledger-models/node/fintekkers/models/security/security_type_pb";
+import { SecurityType } from "@fintekkers/ledger-models/node/wrappers/models/security/security_type";
 import { Tenor } from '@fintekkers/ledger-models/node/wrappers/models/security/term';
 import { Identifier } from '@fintekkers/ledger-models/node/wrappers/models/security/identifier';
 import { IdentifierTypeProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/identifier/identifier_type_pb';
@@ -79,15 +80,14 @@ function identifierTypeNameToProto(name: IdentifierTypeName): IdentifierTypeProt
   }
 }
 
+// SecurityType.fromName (ledger-models 0.1.134+) replaces the local
+// proto-name → enum switch. Throws on unknown name; the call site
+// passes a value that's already constrained to the SecurityTypeName
+// union, so the throw is unreachable at runtime — but the wrapper's
+// error message still lists valid names if a malformed cast slips
+// through.
 function securityTypeNameToProto(name: SecurityTypeName): number {
-  switch (name) {
-    case 'BOND_SECURITY': return SecurityTypeProto.BOND_SECURITY;
-    case 'EQUITY_SECURITY': return SecurityTypeProto.EQUITY_SECURITY;
-    case 'INDEX_SECURITY': return SecurityTypeProto.INDEX_SECURITY;
-    case 'CASH_SECURITY': return SecurityTypeProto.CASH_SECURITY;
-    case 'TIPS': return SecurityTypeProto.TIPS;
-    case 'FRN': return SecurityTypeProto.FRN;
-  }
+  return SecurityType.fromName(name);
 }
 
 export async function FetchSecurity(

--- a/src/lib/securityFilterTypes.ts
+++ b/src/lib/securityFilterTypes.ts
@@ -42,12 +42,38 @@ export type IdentifierTypeName =
 export const IDENTIFIER_TYPE_NAMES: readonly IdentifierTypeName[] =
   Identifier.getAllTypeNames() as readonly IdentifierTypeName[];
 
+// Friendly UI labels for the dropdown. Centralized here so consumers
+// (IdentifierFilter today; future autocomplete / detail views tomorrow)
+// don't duplicate the strings. Ledger-models could host these long-term
+// next to getAllTypeNames(); this file is the right place until then.
+export const IDENTIFIER_TYPE_LABELS: Record<IdentifierTypeName, string> = {
+  CUSIP: 'CUSIP',
+  ISIN: 'ISIN',
+  EXCH_TICKER: 'Ticker',
+  SERIES_ID: 'Series ID',
+  OSI: 'OSI',
+  FIGI: 'FIGI',
+  CASH: 'Cash',
+};
+
+// Placeholder examples per identifier type. Same centralization rationale
+// as IDENTIFIER_TYPE_LABELS — IdentifierFilter consumes these today;
+// future search/autocomplete consumers will too.
+export const IDENTIFIER_TYPE_PLACEHOLDERS: Record<IdentifierTypeName, string> = {
+  CUSIP: 'e.g. 912828ZT0',
+  ISIN: 'e.g. GB0002404557',
+  EXCH_TICKER: 'e.g. AAPL',
+  SERIES_ID: 'e.g. CPIAUCSL',
+  OSI: 'e.g. AAPL  240119C00150000',
+  FIGI: 'e.g. BBG000B9XRY4',
+  CASH: 'e.g. USD',
+};
+
 // ----- SecurityTypeProto -----
 
 // Was hand-typed pre-0.1.134 (only 6 entries: BOND/EQUITY/INDEX/CASH/TIPS/FRN).
 // The wrapper now exposes the full 8-entry set (adds FX_SPOT and
 // EQUITY_INDEX_SECURITY) — the dropdown picks them up automatically.
-// Friendly labels live with the consumer primitive (SecurityTypeFilter.svelte).
 export type SecurityTypeName =
   | 'CASH_SECURITY'
   | 'EQUITY_SECURITY'
@@ -61,11 +87,24 @@ export type SecurityTypeName =
 export const SECURITY_TYPE_NAMES: readonly SecurityTypeName[] =
   SecurityType.getAllTypeNames() as readonly SecurityTypeName[];
 
+// Friendly UI labels for the dropdown. Hides the `_SECURITY` suffix while
+// the URL/proto still carries the canonical name (?securityType=BOND_SECURITY).
+export const SECURITY_TYPE_LABELS: Record<SecurityTypeName, string> = {
+  BOND_SECURITY: 'Bond',
+  EQUITY_SECURITY: 'Equity',
+  INDEX_SECURITY: 'Index',
+  CASH_SECURITY: 'Cash',
+  TIPS: 'TIPS',
+  FRN: 'FRN',
+  FX_SPOT: 'FX Spot',
+  EQUITY_INDEX_SECURITY: 'Equity Index',
+};
+
 // ----- AssetClassProto -----
 
-// CASH_ASSET_CLASS is the proto name due to package-wide enum collision
-// with IdentifierTypeProto.CASH; the friendly 'Cash' label in
-// AssetClassFilter hides the wart from end users.
+// CASH_ASSET_CLASS is the proto name due to a package-wide enum collision
+// with IdentifierTypeProto.CASH; the friendly 'Cash' label below hides
+// the wart from end users.
 export type AssetClassName =
   | 'FIXED_INCOME'
   | 'EQUITY'
@@ -74,3 +113,10 @@ export type AssetClassName =
 
 export const ASSET_CLASS_NAMES: readonly AssetClassName[] =
   AssetClass.getAllTypeNames() as readonly AssetClassName[];
+
+export const ASSET_CLASS_LABELS: Record<AssetClassName, string> = {
+  FIXED_INCOME: 'Fixed Income',
+  EQUITY: 'Equity',
+  CASH_ASSET_CLASS: 'Cash',
+  INDEX: 'Index',
+};

--- a/src/lib/securityFilterTypes.ts
+++ b/src/lib/securityFilterTypes.ts
@@ -4,23 +4,29 @@
  * Why a separate module? `$lib/security.ts` imports `@grpc/grpc-js` for the
  * server-side search; pulling it into a Svelte component (e.g. SecuritySelect)
  * drags grpc-js into the client bundle, where `process is not defined`
- * crashes load. This file imports only `Identifier` (a thin wrapper over
- * proto enums) and `SecurityTypeProto` — both proto-only, no grpc.
+ * crashes load. This file imports only the thin wrappers over proto enums
+ * (Identifier, SecurityType, AssetClass) — all proto-only, no grpc.
  *
- * Phase 1 of second-brain#226; updated for ledger-models 0.1.133 to source
- * IDENTIFIER_TYPE_NAMES from the wrapper's `Identifier.getAllTypeNames()`
- * helper. Adding a new IdentifierTypeProto enum entry now propagates to
- * the dropdown automatically without a UI-side edit.
+ * Phase 1 of second-brain#226; updated incrementally:
+ *   - 0.1.133: IDENTIFIER_TYPE_NAMES sourced from Identifier.getAllTypeNames().
+ *   - 0.1.134: SECURITY_TYPE_NAMES + ASSET_CLASS_NAMES sourced from the new
+ *     SecurityType / AssetClass wrappers. Adding a new proto enum entry
+ *     now propagates to the dropdown automatically without a UI-side edit.
+ *
+ * Type-union convention (consistent across all three): hand-typed string
+ * literal union for compile-time exhaustive-switch / narrowing, runtime
+ * list cast to `readonly <Union>[]` from the wrapper helper. When a new
+ * proto enum entry lands, the runtime dropdown picks it up immediately;
+ * the literal union lags by one PR — that's a deliberate review hook
+ * (TS errors on consumer switch statements remind humans to handle the
+ * new case).
  */
 import { Identifier } from '@fintekkers/ledger-models/node/wrappers/models/security/identifier';
+import { SecurityType } from '@fintekkers/ledger-models/node/wrappers/models/security/security_type';
+import { AssetClass } from '@fintekkers/ledger-models/node/wrappers/models/security/asset_class';
 
-// Compile-time literal union — kept hand-typed so consumers get
-// exhaustive-switch / narrowing in TS. Mirrors the proto enum keys
-// returned by Identifier.getAllTypeNames(). If the proto adds a new
-// enum entry, the runtime list below picks it up immediately and the
-// dropdown shows it; the string literal here will lag by one PR but
-// that's a deliberate review hook (TS errors on switch statements
-// remind humans to handle the new case).
+// ----- IdentifierTypeProto -----
+
 export type IdentifierTypeName =
   | 'CUSIP'
   | 'ISIN'
@@ -30,32 +36,41 @@ export type IdentifierTypeName =
   | 'FIGI'
   | 'CASH';
 
-// Runtime list driving UI dropdowns. Sourced from Identifier.getAllTypeNames()
-// (ledger-models 0.1.133+) — proto-declaration order, excludes the
-// UNKNOWN_IDENTIFIER_TYPE sentinel. NOTE: the dropdown order changes vs
-// the previous hand-typed array (was CUSIP-first; now matches proto
-// order: EXCH_TICKER, ISIN, CUSIP, OSI, FIGI, SERIES_ID, CASH). This is
-// the deliberate trade-off for losing the source-of-drift between this
-// file and the proto.
+// Proto-declaration order: EXCH_TICKER, ISIN, CUSIP, OSI, FIGI, SERIES_ID, CASH.
+// (Differs from the pre-0.1.133 hand-typed CUSIP-first order; documented
+// trade-off for losing the source-of-drift between this file and the proto.)
 export const IDENTIFIER_TYPE_NAMES: readonly IdentifierTypeName[] =
   Identifier.getAllTypeNames() as readonly IdentifierTypeName[];
 
-// SecurityTypeProto names supported by /data/securities filtering. The
-// FX_SPOT / EQUITY_INDEX_SECURITY / UNKNOWN_SECURITY_TYPE entries exist on
-// the proto but aren't user-facing today; add here if/when the seed grows.
-export type SecurityTypeName =
-  | 'BOND_SECURITY'
-  | 'EQUITY_SECURITY'
-  | 'INDEX_SECURITY'
-  | 'CASH_SECURITY'
-  | 'TIPS'
-  | 'FRN';
+// ----- SecurityTypeProto -----
 
-export const SECURITY_TYPE_NAMES: readonly SecurityTypeName[] = [
-  'BOND_SECURITY',
-  'EQUITY_SECURITY',
-  'INDEX_SECURITY',
-  'CASH_SECURITY',
-  'TIPS',
-  'FRN',
-] as const;
+// Was hand-typed pre-0.1.134 (only 6 entries: BOND/EQUITY/INDEX/CASH/TIPS/FRN).
+// The wrapper now exposes the full 8-entry set (adds FX_SPOT and
+// EQUITY_INDEX_SECURITY) — the dropdown picks them up automatically.
+// Friendly labels live with the consumer primitive (SecurityTypeFilter.svelte).
+export type SecurityTypeName =
+  | 'CASH_SECURITY'
+  | 'EQUITY_SECURITY'
+  | 'BOND_SECURITY'
+  | 'TIPS'
+  | 'FRN'
+  | 'INDEX_SECURITY'
+  | 'FX_SPOT'
+  | 'EQUITY_INDEX_SECURITY';
+
+export const SECURITY_TYPE_NAMES: readonly SecurityTypeName[] =
+  SecurityType.getAllTypeNames() as readonly SecurityTypeName[];
+
+// ----- AssetClassProto -----
+
+// CASH_ASSET_CLASS is the proto name due to package-wide enum collision
+// with IdentifierTypeProto.CASH; the friendly 'Cash' label in
+// AssetClassFilter hides the wart from end users.
+export type AssetClassName =
+  | 'FIXED_INCOME'
+  | 'EQUITY'
+  | 'CASH_ASSET_CLASS'
+  | 'INDEX';
+
+export const ASSET_CLASS_NAMES: readonly AssetClassName[] =
+  AssetClass.getAllTypeNames() as readonly AssetClassName[];

--- a/src/tests/e2e/securities-search.spec.ts
+++ b/src/tests/e2e/securities-search.spec.ts
@@ -41,6 +41,50 @@ test.describe('/data/securities filter extension', () => {
     await expect(page.getByText(/^AAPL$/).first()).toBeVisible({ timeout: 10_000 });
   });
 
+  test('AssetClassFilter — ?assetClass=FIXED_INCOME round-trips through Fetch', async ({ page }) => {
+    // Phase 3 (#226) — AssetClassFilter primitive on /data/securities.
+    // Loading with the proto-enum name selects the dropdown; clicking
+    // Fetch re-emits the canonical URL shape with assetClass preserved
+    // alongside other params.
+    await page.goto(
+      '/data/securities?identifier=AAPL&identifierType=EXCH_TICKER&assetClass=FIXED_INCOME',
+    );
+    await expect(page.getByRole('button', { name: /Fetch Securities/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const acSelect = page.locator('#asset-class-input');
+    await expect(acSelect, 'AssetClassFilter loaded the URL value').toHaveValue('FIXED_INCOME');
+
+    await page.getByRole('button', { name: /Fetch Securities/ }).click();
+    await page.waitForURL(/\/data\/securities\?.*assetClass=FIXED_INCOME/, { timeout: 10_000 });
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('assetClass'), 'assetClass re-emitted as proto enum').toBe('FIXED_INCOME');
+    expect(params.get('identifier'), 'other params preserved').toBe('AAPL');
+    expect(params.get('identifierType')).toBe('EXCH_TICKER');
+  });
+
+  test('SecurityTypeFilter — ?securityType=BOND_SECURITY round-trips through Fetch', async ({ page }) => {
+    await page.goto(
+      '/data/securities?identifier=AAPL&identifierType=EXCH_TICKER&securityType=BOND_SECURITY',
+    );
+    await expect(page.getByRole('button', { name: /Fetch Securities/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const stSelect = page.locator('#security-type-select');
+    await expect(stSelect, 'SecurityTypeFilter loaded the URL value').toHaveValue('BOND_SECURITY');
+
+    await page.getByRole('button', { name: /Fetch Securities/ }).click();
+    await page.waitForURL(/\/data\/securities\?.*securityType=BOND_SECURITY/, { timeout: 10_000 });
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('securityType')).toBe('BOND_SECURITY');
+    expect(params.get('identifier'), 'other params preserved').toBe('AAPL');
+    expect(params.get('identifierType')).toBe('EXCH_TICKER');
+  });
+
   test('legacy ?identifier=...&identifierType=CUSIP URL shape still works', async ({ page }) => {
     // Existing bookmark shape — no assetClass / issuerName / securityType
     // set, so the page-server applies the pre-#226 defaults (Fixed Income


### PR DESCRIPTION
Follow-up to merged PR #135 (DateFilter + /data/positions migration). Originally dispatched as *"expand PR #135 in place"*; **PR #135 was already merged** when I picked this up (merge commit `f9ad746`), so opening this as a separate PR — same workflow as the prior PR #123-already-merged case.

> ⚠️ **PM-revoked-merge**: human review required before merge. Do not auto-merge.

## What this adds

Two new composable filter primitives, matching the API conventions established in Phase 2 (IdentifierFilter, PR #130) and continued in PR #135 (DateFilter):

- **`src/components/filters/SecurityTypeFilter.svelte`** — dropdown over `SecurityTypeProto` enum names (`BOND_SECURITY`, `EQUITY_SECURITY`, `INDEX_SECURITY`, `CASH_SECURITY`, `TIPS`, `FRN`, `FX_SPOT`, `EQUITY_INDEX_SECURITY`).
- **`src/components/filters/AssetClassFilter.svelte`** — dropdown over `AssetClassProto` enum names (`FIXED_INCOME`, `EQUITY`, `CASH_ASSET_CLASS`, `INDEX`).

Both:
- `bind:value` (proto-enum name string)
- Default `supportedTypes` from the new ledger-models 0.1.134 wrapper helpers (`SecurityType.getAllTypeNames()` / `AssetClass.getAllTypeNames()`).
- Friendly `DEFAULT_LABELS` in `<script context="module">` (overrideable via `labels` prop). `CASH_ASSET_CLASS` displays as "Cash" — hiding the proto-name collision wart with `IdentifierTypeProto.CASH`.
- `selectClass` / `selectId` pass-through (matches IdentifierFilter / DateFilter).
- "All" empty option for the no-filter case.

## ledger-models 0.1.134

Bumped from 0.1.133. Adds the wrapper helpers needed for the primitives. Drive-by: `src/lib/security.ts:securityTypeNameToProto` collapses from a 6-case switch to a single `SecurityType.fromName(name)` call (mirrors the `Identifier.fromName` pattern adopted in PR #134).

## `securityFilterTypes.ts`

`SECURITY_TYPE_NAMES` switched from a hand-typed 6-entry array to `SecurityType.getAllTypeNames()` runtime list — picks up `FX_SPOT` and `EQUITY_INDEX_SECURITY` automatically. Same trade-off as `IDENTIFIER_TYPE_NAMES` post-#134 (literal-union lags by one PR; deliberate review hook).

`ASSET_CLASS_NAMES` + `AssetClassName` added the same way.

## Migration: `SecuritySelect.svelte`

- assetClass `<input type="text">` → `<AssetClassFilter />`. URL convention shifts from free-form `?assetClass=Equity` to proto-enum `?assetClass=EQUITY`.
  - **Backward compat**: `onMount` accepts BOTH shapes via an inline free-form-to-enum lookup, so existing `?assetClass=Equity` bookmarks populate the dropdown with `EQUITY` and re-emit canonical on Fetch.
  - The page-server is unchanged — the value is still passed through as a string to the backend filter (per the dispatch's phased-(a) note: "proto field still string, enum is additive vocabulary").
- securityType `<select>` → `<SecurityTypeFilter />`. Already proto-enum-shaped pre-migration; just swapped inline template for primitive.

URL serialization stays in `fetchPositions` (page-owns-URL convention from Phase 2).

## Tests

- **`securities-search.spec.ts` extended** with 2 new e2e cases:
  - `AssetClassFilter — ?assetClass=FIXED_INCOME round-trips through Fetch` — loads URL value into dropdown, verifies Fetch re-emits with `assetClass=FIXED_INCOME` + other params preserved.
  - `SecurityTypeFilter — ?securityType=BOND_SECURITY round-trips through Fetch` — same pattern.
- **Full Playwright: 18/18** (was 16; +2). Existing 16 stay green.
- **`npx svelte-check`: 165 errors / 210 warnings** — same as main, **zero new errors**.
- **Targeted unit** (`src/components/filters/`, `src/lib/filters/urlState.test.ts`, `src/tests/PortfolioGrid.test.ts`): **38/38**.

## Out of scope (still PR-B)

- `/data/transactions` tradeDate migration to `DateFilter`.
- `/data/securities` issueDate migration to `DateFilter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)