### PR TITLE
svelte-check cleanup PR-A: Locals.user type + import type + TENOR fix

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -11,26 +11,40 @@ interface BrokerUser {
 
 type AppUser = GoogleUser | BrokerUser;
 
-declare namespace App {
+// `declare global` (rather than top-level `declare namespace App`) is
+// required when this file has imports — without it, the file is treated
+// as a module and the App namespace is module-local. SvelteKit's
+// generated $types files reference `App.Locals` from the global scope;
+// without the global wrapper they get an empty Locals and every
+// `locals.user` access lights up as "Property 'user' does not exist on
+// type 'Locals'" (~41 svelte-check errors before this change).
+declare global {
+      namespace App {
 
-      interface Error {
-        [prop:string]:string,
-        error?: object,
-        errors?:object,
-        flash?:{ type: 'success' | 'error'; message: string };
+            interface Error {
+              [prop:string]:string,
+              error?: object,
+              errors?:object,
+              flash?:{ type: 'success' | 'error'; message: string };
+            }
+
+            interface Locals{
+                user: AppUser | null;
+                session: Session | null;
+            }
+
+            interface PageData{
+              pageMetaTags?: MetaTagsProps;
+              isUserLoggedIn?: boolean;
+              form?:any;
+              flash?: { type: 'success' | 'error'; message: string };
+                user?: AppUser | null;
+            }
+
       }
-
-      interface Locals{
-          user: AppUser | null;
-          session: Session | null;
-      }
-
-      interface PageData{
-        pageMetaTags?: MetaTagsProps;
-        isUserLoggedIn?: boolean;
-        form?:any;
-        flash?: { type: 'success' | 'error'; message: string };
-          user?: AppUser | null;
-      }
-
 }
+
+// Marks this file as a module so the `declare global` above takes
+// effect (would already be a module thanks to the imports, but the
+// explicit empty export is the canonical idiom).
+export {};

--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -41,4 +41,11 @@ export interface User {
     googleId: string;
     name: string;
     picture: string;
+    // Optional because the Google-session auth flow doesn't issue a
+    // broker apiKey (only the BrokerUser flow in hooks.server.ts does).
+    // Declared here so consumers that read `locals.user?.apiKey` across
+    // the AppUser union (GoogleUser | BrokerUser) type-check without a
+    // narrowing dance — matches the runtime where Google-flow returns
+    // undefined and broker-flow returns the cookie value.
+    apiKey?: string;
 }

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -5,7 +5,7 @@ import type Transaction from "@fintekkers/ledger-models/node/wrappers/models/tra
 import type BondSecurity from "@fintekkers/ledger-models/node/wrappers/models/security/BondSecurity";
 import { SecurityTypeProto } from "@fintekkers/ledger-models/node/fintekkers/models/security/security_type_pb";
 import pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/field_pb.js';
-import Security from "@fintekkers/ledger-models/node/wrappers/models/security/security";
+import type Security from "@fintekkers/ledger-models/node/wrappers/models/security/security";
 import { UUID } from '@fintekkers/ledger-models/node/wrappers/models/utils/uuid';
 import { PositionFilterOperator } from '@fintekkers/ledger-models/node/fintekkers/models/position/position_util_pb.js';
 const { FieldProto } = pkg;

--- a/src/routes/treasuries3/+page.svelte
+++ b/src/routes/treasuries3/+page.svelte
@@ -9,18 +9,19 @@
   let sortColumn: string | null = null;
   let sortDirection: "asc" | "desc" = "asc";
 
-  // Format date for display
-  function formatDate(dateStr: string | undefined): string {
+  // Format date for display. Accepts both string (per interface for
+  // ISSUE_DATE/MATURITY_DATE) and Date (per interface for TRADE_DATE).
+  function formatDate(dateStr: string | Date | undefined): string {
     if (!dateStr) return "N/A";
     try {
-      const date = new Date(dateStr);
+      const date = dateStr instanceof Date ? dateStr : new Date(dateStr);
       return date.toLocaleDateString("en-US", {
         year: "numeric",
         month: "short",
         day: "numeric",
       });
     } catch {
-      return dateStr;
+      return String(dateStr);
     }
   }
 
@@ -33,13 +34,33 @@
   }
 
   // Parse date for sorting
-  function parseDate(dateStr: string | undefined): Date {
+  function parseDate(dateStr: string | Date | undefined): Date {
     if (!dateStr) return new Date(0);
+    if (dateStr instanceof Date) return dateStr;
     try {
       return new Date(dateStr);
     } catch {
       return new Date(0);
     }
+  }
+
+  // TENOR is delivered as a wrapper-formatted description string
+  // (e.g. "2Y3M", "5Y", "6M") from treasury_positions.ts. The page
+  // wants `{ years, months }` for sortable + tabular display. Parse
+  // here (Path B from the dispatch — keeps the producer interface
+  // matching runtime; the parsing concern stays in the consumer).
+  // Pre-fix the page accessed `.years`/`.months` on the string and
+  // silently rendered blank cells. Format from
+  // ledger-models's `Tenor.getTenorDescription()`: optional Y / M / W /
+  // D segments. We only need Y + M for the table.
+  function parseTenor(tenor: string | undefined): { years: number; months: number } | undefined {
+    if (!tenor) return undefined;
+    const m = tenor.match(/(?:(\d+)Y)?(?:(\d+)M)?/);
+    if (!m) return undefined;
+    const years = m[1] ? parseInt(m[1], 10) : 0;
+    const months = m[2] ? parseInt(m[2], 10) : 0;
+    if (years === 0 && months === 0) return undefined;
+    return { years, months };
   }
 
   // Get sortable value for a transaction
@@ -57,11 +78,11 @@
         return parseDate(txn.ISSUE_DATE).getTime();
       case "MATURITY_DATE":
         return parseDate(txn.MATURITY_DATE).getTime();
-      case "TENOR":
-        if (txn.TENOR) {
-          return (txn.TENOR.years || 0) * 12 + (txn.TENOR.months || 0);
-        }
+      case "TENOR": {
+        const t = parseTenor(txn.TENOR);
+        if (t) return t.years * 12 + t.months;
         return txn.ADJUSTED_TENOR || "";
+      }
       case "DIRECTED_QUANTITY":
         return txn.DIRECTED_QUANTITY || 0;
       default:
@@ -221,6 +242,7 @@
         </thead>
         <tbody>
           {#each sortedTransactions as txn}
+            {@const tenorParsed = parseTenor(txn.TENOR)}
             <tr>
               <td class="identifier">{txn.IDENTIFIER}</td>
               <td>{formatDate(txn.TRADE_DATE)}</td>
@@ -235,9 +257,9 @@
               <td>{formatDate(txn.ISSUE_DATE)}</td>
               <td>{formatDate(txn.MATURITY_DATE)}</td>
               <td>
-                {#if txn.TENOR}
-                  {txn.TENOR.years > 0 ? `${txn.TENOR.years}Y ` : ""}
-                  {txn.TENOR.months > 0 ? `${txn.TENOR.months}M` : ""}
+                {#if tenorParsed}
+                  {tenorParsed.years > 0 ? `${tenorParsed.years}Y ` : ""}
+                  {tenorParsed.months > 0 ? `${tenorParsed.months}M` : ""}
                 {:else}
                   {txn.ADJUSTED_TENOR || "N/A"}
                 {/if}


### PR DESCRIPTION
PR-A of the svelte-check cleanup batch (per analysis: 165 → ~80 errors target). Three high-leverage fixes.

> ⚠️ **PM-revoked-merge**: human review required before merge. Do not auto-merge.

## Result vs target

**165 → 117 errors (−48)**, 210 warnings unchanged. Below the dispatch's ~85 estimate. Root cause analysis in each section below; tl;dr the import-type bucket is mostly upstream (`node_modules/@fintekkers/ledger-models/...`) and can't be fixed without a ledger-models PR.

| Fix | Errors fixed | Notes |
|---|---:|---|
| 1. `Locals.user` ambient type | **−39** | matches dispatch ~40 estimate |
| 2. Bulk `import type` | **−1** | dispatch estimated ~43; audit shows 41 of 42 are upstream in node_modules — out of scope |
| 3. TENOR string-vs-object mismatch | **−8** | dispatch estimated ~16; the rest were Date/string mismatches I fixed as part of the cascade |

## Fix 1: `Locals.user` ambient type

`src/app.d.ts` had `declare namespace App` at file top, but the file has imports — so it's a module, not ambient global. SvelteKit's `$types` couldn't see `App.Locals`, every `locals.user` access lit up.

**Fix**: wrap in `declare global { namespace App { … } }` + `export {}`. Then `apiKey?: string` added to `GoogleUser` so `locals.user?.apiKey` access type-checks across the union (Google flow has no apiKey at runtime, broker flow does — optional matches).

## Fix 2: `import type` migration

Dispatch named `treasury_positions.ts` and `prices/+page.server.ts` as targets — neither actually has this error category (they have unrelated type errors). Audit of the 42 "import never used as value" errors:
- **1 in our project**: `src/lib/transactions.ts:8` (`Security` was value-imported, only used as type) — fixed.
- **41 in node_modules/@fintekkers/ledger-models/...**: wrapper `.ts` source files. svelte-check follows imports into node_modules (the wrappers ship `.ts` source alongside compiled `.js` + `.d.ts`); `skipLibCheck` only skips `.d.ts`. **Out of scope — needs a ledger-models PR.**

## Fix 3: TENOR string-vs-object mismatch (real product bug, path B)

`/treasuries3/+page.svelte` read `txn.TENOR.years` / `.months` but the producer (`treasury_positions.ts`) emits `TENOR` as a description string (`"2Y3M"`). Pre-fix the cells rendered **blank** silently — `undefined > 0` is false, so both ternary branches fall through and `{:else}` doesn't trigger because the truthy non-empty string short-circuits the `{#if}`.

**Picked path B** (parse in page, keep producer interface as `string`) over path A (object in producer) because path A cascaded into `treasury_graphs.ts` + `treasury_graphs.test.ts` type changes that exceeded PR-A scope. Path B is a pure consumer-side parse: regex extracts `{years, months}`, page renders.

Side-effects of path B:
- `{@const tenorParsed = parseTenor(txn.TENOR)}` must be immediate child of `{#each}` — moved.
- `formatDate` widened to accept `Date | string | undefined` since `TRADE_DATE` is `Date` on the interface and the function was string-only.

### Reviewer checklist for path B

- [ ] Manual check at `https://localhost:443/treasuries3` — TENOR cells render `NY NM` form (e.g. "2Y 3M") instead of blank.
  - **Heads-up**: pre-existing 500 blocks visual verification. `treasury_positions.ts:getTreasuryTransactions` doesn't receive `locals.user?.apiKey`; gRPC returns UNAUTHENTICATED; page 500s entirely. Separate auth bug, not introduced by this PR. Once that's fixed (separate ticket), the TENOR cells should render correctly.

## Verification

- `npx svelte-check`: **165 → 117 errors** (−48); 210 warnings unchanged.
- `npx playwright test`: **18/18 pass** (no regressions).
- `npx vitest run`: 24 failed / 519 passed — same as main baseline, no new failures.

## Out of scope (per dispatch)

- 41 upstream `import type` errors in `node_modules/@fintekkers/ledger-models/...` — needs a ledger-models PR.
- `/treasuries3` auth pass-through bug — separate ticket.
- SCSS `@extend` errors, null-narrowing, vitest fixture drift, etc. — PR-B and backlog items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)