### PR TITLE
DateFilter rollout: /data/transactions + /data/securities (Phase 3 of #226, PR-B)

### DIFF
--- a/src/components/widgets/SecuritySelect.svelte
+++ b/src/components/widgets/SecuritySelect.svelte
@@ -13,6 +13,8 @@
   import IdentifierFilter from "../filters/IdentifierFilter.svelte";
   import SecurityTypeFilter from "../filters/SecurityTypeFilter.svelte";
   import AssetClassFilter from "../filters/AssetClassFilter.svelte";
+  import DateFilter from "../filters/DateFilter.svelte";
+  import type { DateOperator } from "../filters/DateFilter.svelte";
 
   // Phase 2/3 of second-brain#226: filter primitives now own their controls.
   // - Phase 2 (PR #130): identifier-type dropdown + value → IdentifierFilter.
@@ -36,8 +38,13 @@
 
   let identifierInput: string = "";
   let identifierType: IdentifierTypeName = "CUSIP";
+  // Phase 3 PR-B of #226: issueDate UX uses the shared DateFilter
+  // primitive. Operators restricted to greater_than / lesser_than —
+  // FetchSecurity in $lib/security only maps those two; widening the
+  // dropdown without backend support would surface a silent no-op.
   let issueDateInput: string = "";
-  let issueDateOperator: "greater_than" | "lesser_than" | "" = "";
+  let issueDateOperator: Extract<DateOperator, "greater_than" | "lesser_than"> | "" = "";
+  const ISSUE_DATE_OPERATORS = ["greater_than", "lesser_than"] as const satisfies readonly DateOperator[];
   let assetClassInput: AssetClassName | "" = "";
   let issuerNameInput: string = "";
   let securityTypeInput: SecurityTypeName | "" = "";
@@ -171,27 +178,16 @@
     </div>
   </div>
   <div class="security-select-container flex flex-col sm:flex-row gap-2 mt-2">
-    <div class="text-white">
+    <div class="text-white issue-date-filter-cell">
       <h4>Issue Date Filter:</h4>
-      <input
-        type="date"
-        id="issue-date-input"
-        bind:value={issueDateInput}
-        class="filter-input text-black"
+      <DateFilter
+        bind:date={issueDateInput}
+        bind:operator={issueDateOperator}
+        operators={ISSUE_DATE_OPERATORS}
+        inputClass="filter-input text-black"
+        selectClass="filter-select text-black"
+        inputId="issue-date-input"
       />
-    </div>
-    <div class="text-white">
-      <h4>Operator:</h4>
-      <select
-        id="issue-date-operator"
-        bind:value={issueDateOperator}
-        class="filter-select text-black"
-        disabled={!issueDateInput}
-      >
-        <option value="">Select operator...</option>
-        <option value="greater_than">Greater Than</option>
-        <option value="lesser_than">Lesser Than</option>
-      </select>
     </div>
     <div class="text-white flex items-end">
       <button class="security-button" on:click={fetchSecurities}>

--- a/src/components/widgets/TransactionSelect.svelte
+++ b/src/components/widgets/TransactionSelect.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  /**
+   * Filter bar for /data/transactions.
+   *
+   * Phase 3 PR-B of second-brain#226: introduces tradeDate filtering on
+   * the transactions page (no equivalent UX existed previously). Mirrors
+   * the URL conventions on /data/positions exactly:
+   *   ?tradeDate=YYYY-MM-DD
+   *   &tradeDateOperator=greater_than|lesser_than|lesser_than_or_equals
+   * so users moving between the two pages don't have to relearn the
+   * filter shape.
+   *
+   * portfolioId is preserved across re-submits via buildFilterUrl's
+   * inheritKeys (matches the #220-class guard in PositionSelect): when
+   * the user lands here from /data/portfolios with ?portfolioId=…, that
+   * scope survives the Filter button click.
+   *
+   * The filter is a coupled (date, operator) pair — emit both or neither
+   * so the page-server doesn't apply a half-formed filter (matches the
+   * pattern in PositionSelect.fetchPositions).
+   */
+  import { onMount } from "svelte";
+  import { buildFilterUrl } from "$lib/filters/urlState";
+  import DateFilter from "../filters/DateFilter.svelte";
+  import type { DateOperator } from "../filters/DateFilter.svelte";
+
+  let tradeDateInput: string = "";
+  let tradeDateOperator: DateOperator | "" = "";
+
+  function fetchTransactions() {
+    if (typeof window === "undefined") return;
+
+    const trimmedTradeDate = tradeDateInput.trim();
+    const tradeDateOverride =
+      trimmedTradeDate && tradeDateOperator ? trimmedTradeDate : undefined;
+    const tradeDateOperatorOverride =
+      trimmedTradeDate && tradeDateOperator ? tradeDateOperator : undefined;
+
+    const url = buildFilterUrl(
+      "/data/transactions",
+      new URLSearchParams(window.location.search),
+      {
+        tradeDate: tradeDateOverride,
+        tradeDateOperator: tradeDateOperatorOverride,
+      },
+      // Carry through the inbound portfolio scope so the Filter button
+      // doesn't silently widen a portfolio-scoped view back to the
+      // global transaction list (#220-class guard).
+      ["portfolioId"],
+    );
+
+    window.location.href = url;
+  }
+
+  onMount(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tradeDateFromUrl = params.get("tradeDate");
+    if (tradeDateFromUrl) tradeDateInput = tradeDateFromUrl;
+
+    const opFromUrl = params.get("tradeDateOperator");
+    if (
+      opFromUrl === "greater_than" ||
+      opFromUrl === "lesser_than" ||
+      opFromUrl === "lesser_than_or_equals"
+    ) {
+      tradeDateOperator = opFromUrl;
+    }
+  });
+</script>
+
+<div class="transaction-select-container mt-6 mx-10 flex flex-col sm:flex-row gap-2">
+  <div class="text-white date-filter-cell">
+    <h4>Trade Date Filter:</h4>
+    <DateFilter
+      bind:date={tradeDateInput}
+      bind:operator={tradeDateOperator}
+      inputClass="transaction-select-input text-black"
+      selectClass="transaction-select-input text-black"
+      inputId="trade-date-input"
+    />
+  </div>
+  <div class="text-white flex items-end">
+    <button class="transaction-button" on:click={fetchTransactions}>
+      Filter
+    </button>
+  </div>
+</div>
+
+<style lang="scss">
+  @import "../../styles/_shared.scss";
+
+  h4 {
+    margin: 4px 0;
+    font-size: 0.875rem;
+  }
+
+  .transaction-button {
+    background-color: $success;
+    color: $bgc-color;
+    font-weight: bold;
+    padding: 8px 24px;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+    &:hover {
+      background-color: lighten($success, 5%);
+      transform: translateY(-1px);
+    }
+
+    &:active {
+      transform: translateY(0);
+    }
+  }
+
+  // .transaction-select-input is passed via inputClass / selectClass
+  // into DateFilter (Phase 3 PR-B of #226). The component renders those
+  // classes onto its <select>/<input>, which live in a child component
+  // scope, so Svelte's scoped CSS would drop the rule as unused. :global
+  // keeps it applying; the .transaction-select-container ancestor
+  // confines blast radius to TransactionSelect's tree.
+  :global(.transaction-select-container .transaction-select-input) {
+    padding: 4px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    width: 100%;
+    font-size: 0.875rem;
+    height: 38px;
+    box-sizing: border-box;
+    background-color: white;
+  }
+
+  :global(.transaction-select-container .transaction-select-input:disabled) {
+    background-color: #f0f0f0;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -124,16 +124,48 @@ let FetchTransactionWithFilter = async function FetchTransactionWithFilter(filte
   }
 };
 
-let FetchTransaction = async function FetchTransaction(apiKey?: string): Promise<TransactionData[]> {
+// Phase 3 PR-B of #226: optional tradeDate filter on /data/transactions.
+// Mirrors the operator vocabulary in positions.ts:FetchPosition so the
+// URL conventions stay consistent across the two pages.
+type TradeDateOperator = 'greater_than' | 'lesser_than' | 'lesser_than_or_equals';
+
+function applyTradeDateFilter(
+  filter: positionFilter.PositionFilter,
+  tradeDate?: string,
+  tradeDateOperator?: TradeDateOperator,
+): void {
+  if (!tradeDate || tradeDate.trim() === '' || !tradeDateOperator) return;
+  const tradeDateObj = new Date(tradeDate);
+  const operator =
+    tradeDateOperator === 'greater_than'
+      ? PositionFilterOperator.MORE_THAN
+      : tradeDateOperator === 'lesser_than_or_equals'
+        ? PositionFilterOperator.LESS_THAN_OR_EQUALS
+        : PositionFilterOperator.LESS_THAN;
+  filter.addFilter(FieldProto.TRADE_DATE, operator, tradeDateObj);
+}
+
+let FetchTransaction = async function FetchTransaction(
+  apiKey?: string,
+  tradeDate?: string,
+  tradeDateOperator?: TradeDateOperator,
+): Promise<TransactionData[]> {
   const filter = new positionFilter.PositionFilter();
   filter.addEqualsFilter(FieldProto.ASSET_CLASS, "Fixed Income");
+  applyTradeDateFilter(filter, tradeDate, tradeDateOperator);
   return FetchTransactionWithFilter(filter, apiKey);
 };
 
-let FetchTransactionByPortfolio = async function FetchTransactionByPortfolio(portfolioId: string, apiKey?: string): Promise<TransactionData[]> {
+let FetchTransactionByPortfolio = async function FetchTransactionByPortfolio(
+  portfolioId: string,
+  apiKey?: string,
+  tradeDate?: string,
+  tradeDateOperator?: TradeDateOperator,
+): Promise<TransactionData[]> {
   const filter = new positionFilter.PositionFilter();
   const portfolioUuid = new UUID(UUID.fromString(portfolioId.trim()));
   filter.addFilter(FieldProto.PORTFOLIO_ID, PositionFilterOperator.EQUALS, portfolioUuid);
+  applyTradeDateFilter(filter, tradeDate, tradeDateOperator);
   const results = await FetchTransactionWithFilter(filter, apiKey);
   // Sort descending by trade date (most recent first)
   results.sort((a, b) => b.transactionTradeDate.localeCompare(a.transactionTradeDate));
@@ -141,4 +173,4 @@ let FetchTransactionByPortfolio = async function FetchTransactionByPortfolio(por
 };
 
 export { FetchTransactionWithFilter, FetchTransaction, FetchTransactionByPortfolio };
-export type { TransactionData };
+export type { TransactionData, TradeDateOperator };

--- a/src/routes/(authenticated)/data/transactions/+page.server.ts
+++ b/src/routes/(authenticated)/data/transactions/+page.server.ts
@@ -1,4 +1,4 @@
-import { FetchTransaction, FetchTransactionByPortfolio } from "$lib/transactions";
+import { FetchTransaction, FetchTransactionByPortfolio, type TradeDateOperator } from "$lib/transactions";
 import { deleteEntity } from '$lib/entity-delete';
 
 /** @type {import('../../../../../.svelte-kit/types/src/routes').PageServerLoad} */
@@ -10,9 +10,24 @@ export async function load({ locals, url }) {
   // dump every transaction across every portfolio onto the page.
   const portfolioId = url.searchParams.get('portfolioId');
   const apiKey = locals.user?.apiKey;
+
+  // Phase 3 PR-B of #226: optional tradeDate filter. URL convention
+  // mirrors /data/positions exactly (?tradeDate=YYYY-MM-DD&
+  // tradeDateOperator=greater_than|lesser_than|lesser_than_or_equals).
+  // Both URL params required for the filter to apply — half-formed
+  // shapes drop both, matching the form's emit guard.
+  const tradeDate = url.searchParams.get('tradeDate') ?? undefined;
+  const rawTradeDateOp = url.searchParams.get('tradeDateOperator');
+  const tradeDateOperator: TradeDateOperator | undefined =
+    rawTradeDateOp === 'greater_than' ||
+    rawTradeDateOp === 'lesser_than' ||
+    rawTradeDateOp === 'lesser_than_or_equals'
+      ? rawTradeDateOp
+      : undefined;
+
   const transactions = portfolioId
-    ? await FetchTransactionByPortfolio(portfolioId, apiKey)
-    : await FetchTransaction(apiKey);
+    ? await FetchTransactionByPortfolio(portfolioId, apiKey, tradeDate, tradeDateOperator)
+    : await FetchTransaction(apiKey, tradeDate, tradeDateOperator);
   return {
     transactions,
     portfolioId: portfolioId || null,

--- a/src/routes/(authenticated)/data/transactions/+page.svelte
+++ b/src/routes/(authenticated)/data/transactions/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Transaction from "../../../../components/widgets/TransactionGrid.svelte";
+  import TransactionSelect from "../../../../components/widgets/TransactionSelect.svelte";
   import DeleteConfirmModal from "../../../../components/widgets/DeleteConfirmModal.svelte";
   import { enhance } from '$app/forms';
   export let data: import("./$types").PageData;
@@ -46,6 +47,8 @@
     setTimeout(() => { window.location.reload(); }, 1500);
   }
 </script>
+
+<TransactionSelect />
 
 {#if deleteSuccess}
   <div class="success-banner">{deleteSuccess}</div>

--- a/src/tests/treasury-curve-display.test.ts
+++ b/src/tests/treasury-curve-display.test.ts
@@ -108,7 +108,13 @@ describe('/treasuries page – TransactionData shape', () => {
 	const lib = fs.readFileSync(path.resolve('src/lib/transactions.ts'), 'utf-8');
 
 	test('TransactionData interface is exported', () => {
-		expect(lib).toContain('export type { TransactionData }');
+		// Match `TransactionData` appearing inside any `export type { ... }`
+		// list. The previous literal-substring assertion broke when
+		// PR-B (Phase 3 of #226) extended the export to also include
+		// TradeDateOperator. Same pattern as the stale-baseline cleanup
+		// in PR #139 — assert the intent (type is exported) not the
+		// exact line shape.
+		expect(lib).toMatch(/export\s+type\s*\{[^}]*\bTransactionData\b[^}]*\}/);
 	});
 
 	const requiredFields = [

--- a/tests/e2e/portfolio-soma-transactions.spec.ts
+++ b/tests/e2e/portfolio-soma-transactions.spec.ts
@@ -66,4 +66,67 @@ test.describe('/data/portfolios → /data/transactions (SOMA)', () => {
     expect(wrapperOverflow.x).toBe('visible');
     expect(wrapperOverflow.y).toBe('visible');
   });
+
+  // Phase 3 PR-B of #226: tradeDate DateFilter on /data/transactions.
+  test('tradeDate + tradeDateOperator round-trip through Filter with portfolioId preserved', async ({ page }) => {
+    await page.goto('/data/portfolios');
+    const txnsLink = page
+      .locator('table tbody tr').filter({ hasText: PORTFOLIO_NAME }).first()
+      .getByRole('link', { name: /^Txns$/ });
+    const href = await txnsLink.getAttribute('href');
+    const portfolioId = new URL(href!, page.url()).searchParams.get('portfolioId')!;
+
+    // Land with both URL params set; DateFilter (via TransactionSelect's
+    // onMount) should populate the date input and operator select. The
+    // operator dropdown must be enabled because the date is set.
+    await page.goto(
+      `/data/transactions?portfolioId=${portfolioId}` +
+      `&tradeDate=2026-05-06&tradeDateOperator=lesser_than_or_equals`,
+    );
+
+    const dateInput = page.locator('#trade-date-input');
+    await expect(dateInput).toBeVisible({ timeout: 10_000 });
+    await expect(dateInput).toHaveValue('2026-05-06');
+    const opSelect = page.getByLabel('Date operator');
+    await expect(opSelect).toHaveValue('lesser_than_or_equals');
+    await expect(opSelect).toBeEnabled();
+
+    // Click Filter → the form re-emits the same URL shape; portfolioId
+    // is carried via TransactionSelect's inheritKeys (#220 guard).
+    await page.getByRole('button', { name: /^Filter$/ }).click();
+    await page.waitForURL(/\/data\/transactions\?.*tradeDate=/, { timeout: 10_000 });
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('tradeDate')).toBe('2026-05-06');
+    expect(params.get('tradeDateOperator')).toBe('lesser_than_or_equals');
+    expect(params.get('portfolioId'), '#220 guard: portfolioId preserved').toBe(portfolioId);
+  });
+
+  test('tradeDate without operator: filter dropped on re-emit (half-applied guard)', async ({ page }) => {
+    await page.goto('/data/portfolios');
+    const txnsLink = page
+      .locator('table tbody tr').filter({ hasText: PORTFOLIO_NAME }).first()
+      .getByRole('link', { name: /^Txns$/ });
+    const href = await txnsLink.getAttribute('href');
+    const portfolioId = new URL(href!, page.url()).searchParams.get('portfolioId')!;
+
+    // URL has tradeDate but no operator. DateFilter populates the date
+    // input; operator stays empty. Clicking Filter drops both params
+    // on re-emit (the form's emit guard mirrors the page-server's
+    // half-formed-filter rule).
+    await page.goto(
+      `/data/transactions?portfolioId=${portfolioId}&tradeDate=2026-05-06`,
+    );
+    const dateInput = page.locator('#trade-date-input');
+    await expect(dateInput).toHaveValue('2026-05-06');
+    await expect(page.getByLabel('Date operator')).toHaveValue('');
+
+    await page.getByRole('button', { name: /^Filter$/ }).click();
+    await page.waitForURL(/\/data\/transactions/, { timeout: 10_000 });
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('tradeDate'), 'half-applied filter dropped').toBeNull();
+    expect(params.get('tradeDateOperator'), 'no orphan operator emitted').toBeNull();
+    expect(params.get('portfolioId'), '#220 guard: portfolioId preserved').toBe(portfolioId);
+  });
 });

--- a/tests/e2e/securities-search.spec.ts
+++ b/tests/e2e/securities-search.spec.ts
@@ -98,4 +98,53 @@ test.describe('/data/securities filter extension', () => {
       timeout: 15_000,
     });
   });
+
+  // Phase 3 PR-B of #226: issueDate DateFilter on /data/securities.
+  test('issueDate + issueDateOperator round-trip through Fetch with other params preserved', async ({ page }) => {
+    // Backend supports greater_than / lesser_than only on issueDate
+    // (FetchSecurity in $lib/security maps just these two). DateFilter
+    // is restricted via the `operators` prop to match.
+    await page.goto(
+      '/data/securities?identifier=AAPL&identifierType=EXCH_TICKER' +
+      '&issueDate=2024-01-15&issueDateOperator=greater_than',
+    );
+    await expect(page.getByRole('button', { name: /Fetch Securities/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const dateInput = page.locator('#issue-date-input');
+    await expect(dateInput).toHaveValue('2024-01-15');
+    const opSelect = page.getByLabel('Date operator');
+    await expect(opSelect).toHaveValue('greater_than');
+    await expect(opSelect).toBeEnabled();
+
+    await page.getByRole('button', { name: /Fetch Securities/ }).click();
+    await page.waitForURL(/\/data\/securities\?.*issueDate=/, { timeout: 10_000 });
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('issueDate')).toBe('2024-01-15');
+    expect(params.get('issueDateOperator')).toBe('greater_than');
+    expect(params.get('identifier'), 'other params preserved').toBe('AAPL');
+    expect(params.get('identifierType')).toBe('EXCH_TICKER');
+  });
+
+  test('issueDate operator dropdown excludes lesser_than_or_equals (backend-supported subset)', async ({ page }) => {
+    // FetchSecurity's signature only accepts 'greater_than' | 'lesser_than'.
+    // DateFilter's `operators` prop on /data/securities trims the third
+    // option (lesser_than_or_equals) so the dropdown can't surface a
+    // selection the page-server would silently drop.
+    await page.goto('/data/securities?issueDate=2024-01-15&issueDateOperator=greater_than');
+    await expect(page.getByRole('button', { name: /Fetch Securities/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Inspect the operator <select>'s options. Should be exactly 3:
+    // the empty placeholder + greater_than + lesser_than. No
+    // lesser_than_or_equals option.
+    const opValues = await page.getByLabel('Date operator').evaluate((el) => {
+      const select = el as HTMLSelectElement;
+      return Array.from(select.options).map((o) => o.value);
+    });
+    expect(opValues).toEqual(['', 'greater_than', 'lesser_than']);
+  });
 });


### PR DESCRIPTION
Phase 3 PR-B of [second-brain#226](https://github.com/FinTekkers/second-brain/issues/226). Completes the DateFilter primitive rollout — primitive shipped in PR #135, consumed on `/data/positions` in PR-A; this PR closes out the remaining two consumers.

> ⚠️ **PM-revoked-merge**: human review required. Do not auto-merge.

## Two consumer migrations

### `/data/securities` — issueDate (existing UX → primitive)

Inline `<input type="date">` + operator `<select>` in `SecuritySelect.svelte` replaced with `<DateFilter>`. URL convention unchanged: `?issueDate=YYYY-MM-DD&issueDateOperator=greater_than|lesser_than`. Page-server untouched.

**Operator decision**: passed `operators={['greater_than', 'lesser_than']}` — FetchSecurity in `$lib/security` only maps those two. Surfacing the DateFilter default 3rd option (`lesser_than_or_equals`) would let users pick a value the page-server silently drops. Better to hide it; widen to 3 operators alongside a server-side change later.

### `/data/transactions` — tradeDate (new UX, no prior filter existed)

Per dispatch's allowance ("If no … filter exists yet, add a fresh one and wire it through"):

| Layer | Change |
|---|---|
| `$lib/transactions.ts` | Optional `tradeDate?` + `tradeDateOperator?` on `FetchTransaction` and `FetchTransactionByPortfolio`. Shared `applyTradeDateFilter` helper builds the `TRADE_DATE` PositionFilter (mirrors the switch in `positions.ts`). Existing 2-arg callers in `/data/portfolios/+page.server.ts` stay valid. |
| `/data/transactions/+page.server.ts` | Reads `tradeDate` + `tradeDateOperator` URL params, passes through. URL shape matches `/data/positions` exactly: `?tradeDate=YYYY-MM-DD&tradeDateOperator=greater_than\|lesser_than\|lesser_than_or_equals`. |
| **NEW** `src/components/widgets/TransactionSelect.svelte` | Minimal filter bar (DateFilter + "Filter" button). `buildFilterUrl` with `inheritKeys: ['portfolioId']` carries the inbound portfolio scope across re-submits (#220 guard). |
| `+page.svelte` | Mount `<TransactionSelect />` above the grid. |

**Operator decision**: full 3-option set (matches `/data/positions` so users moving between pages keep the same vocabulary).

## Wrapper-gap flag (per dispatch)

The operator-mapping switch (`'greater_than' → MORE_THAN`, etc.) now lives in three places: `$lib/positions.ts`, `$lib/transactions.ts`, `$lib/security.ts`. A `PositionFilterOperator.fromName()` helper in ledger-models would consolidate. Not blocking PR-B; flagged for a future upstream PR.

## Drive-by

`src/tests/treasury-curve-display.test.ts` had a literal-substring assertion that broke when I extended the `export type` list to include `TradeDateOperator`. Replaced with a regex matching `TransactionData` in any `export type { … }` list — same brittle-pattern fix as the stale-baseline cleanup in PR #139.

## Verification

| Check | Before | After |
|---|---:|---:|
| `npx playwright test` | 18/18 | **22/22** (4 new cases) |
| `npx vitest run` | 0 failed | **0 failed** (one regression caught + fixed via the drive-by) |
| `npx svelte-check` | 117 / 210 | **117 / 210** (no new errors) |

### New e2e cases

`tests/e2e/portfolio-soma-transactions.spec.ts` (+2):
- `tradeDate + tradeDateOperator round-trip through Filter with portfolioId preserved` — load both URL params, verify form populated, click Filter, assert URL re-emits with portfolioId carried via inheritKeys.
- `tradeDate without operator: filter dropped on re-emit` — half-applied guard mirrors the page-server's URL parser.

`tests/e2e/securities-search.spec.ts` (+2):
- `issueDate + issueDateOperator round-trip through Fetch with other params preserved`.
- `issueDate operator dropdown excludes lesser_than_or_equals` — confirms the backend-supported subset is enforced at the dropdown.

## Out of scope (per dispatch)

- `PortfolioFilter` / `MeasureMultiselectFilter` / `HideZerosToggle` — future Phase 3 PRs.
- Upstream ledger-models cleanup (41 import-type errors) — separate batch.
- Worker OOM on full vitest runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)