### PR TITLE
svelte-check cleanup PR-B: UUID-vs-Identifier + keyof formError + EventTarget.value

### DIFF
--- a/src/components/login/InputFieldText.svelte
+++ b/src/components/login/InputFieldText.svelte
@@ -1,7 +1,15 @@
 <script lang='ts'>
   import type { formError } from "$lib/types";
 
-  export let fieldName: keyof formError;
+  // fieldName was previously typed `keyof formError`, which TS resolves
+  // to `string | number | symbol`. The downstream consumers
+  // (handleChange/handleFocus/handleBlur/displayError) and the DOM
+  // attribute bindings (`for={fieldName}`, `id={fieldName}`,
+  // `name={fieldName}`) all expect plain strings — `keyof formError`
+  // can't narrow there. Loosened to `string`; formError already has
+  // `[x: string]: any`, so any string fieldName indexes correctly into
+  // the `inputValue[fieldName]` lookup below.
+  export let fieldName: string;
   export let inputValue: formError;
   export let focusedElement: string | null;
   export let handleChange: (fieldName: string, value: string) => void;
@@ -12,16 +20,6 @@
   // Check if form is not null before using it to initialize inputValue
   let form: formError | null = null;
   $: inputValue = form ? form : {};
-
-  // Display function
-  const display = (fieldName: string) => {
-  if (form && form.formError) { // Check if form and formError are defined
-    const errors = Array.from(form.formError); // Ensure form.formError is defined
-    return errors.includes(fieldName);
-  }
-  return false;
-};
-
 </script>
 
 <label for={fieldName}>
@@ -30,7 +28,7 @@
   </span>
   <input
     on:focus={() => handleFocus(fieldName)}
-    on:change={(event) => handleChange(fieldName, event?.target.value)}
+    on:change={(event) => handleChange(fieldName, (event.target as HTMLInputElement).value)}
     on:blur={() => handleBlur(fieldName)}
     id={fieldName}
     name={fieldName}

--- a/src/components/login/InputFieldTextArea.svelte
+++ b/src/components/login/InputFieldTextArea.svelte
@@ -1,7 +1,10 @@
 <script lang='ts'>
   import type { formError } from "$lib/types";
 
-  export let fieldName: keyof formError;
+  // Same fix as InputFieldText: `keyof formError` is `string | number |
+  // symbol` which can't satisfy the string-typed downstream consumers.
+  // formError has `[x: string]: any`, so any string keys index in.
+  export let fieldName: string;
   export let inputValue: formError;
   export let focusedElement: string | null;
   export let handleChange: (fieldName: string, value: string) => void;
@@ -12,16 +15,6 @@
   // Check if form is not null before using it to initialize inputValue
   let form: formError | null = null;
   $: inputValue = form ? form : {};
-
-  // Display function
-  const display = (fieldName: string) => {
-  if (form && form.formError) { // Check if form and formError are defined
-    const errors = Array.from(form.formError); // Ensure form.formError is defined
-    return errors.includes(fieldName);
-  }
-  return false;
-};
-
 </script>
 
 <label for={fieldName}>
@@ -30,7 +23,7 @@
   </span>
   <textarea
     on:focus={() => handleFocus(fieldName)}
-    on:change={(event) => handleChange(fieldName, event?.target.value)}
+    on:change={(event) => handleChange(fieldName, (event.target as HTMLTextAreaElement).value)}
     on:blur={() => handleBlur(fieldName)}
     id={fieldName}
     name={fieldName}

--- a/src/lib/curvePrices.ts
+++ b/src/lib/curvePrices.ts
@@ -9,6 +9,7 @@ import { QueryPriceRequestProto, PriceHorizonProto, PriceFrequencyProto } from '
 import { ZonedDateTime } from '@fintekkers/ledger-models/node/wrappers/models/utils/datetime';
 import { PositionFilter } from '@fintekkers/ledger-models/node/wrappers/models/position/positionfilter';
 import { UUID } from '@fintekkers/ledger-models/node/wrappers/models/utils/uuid';
+import type { Identifier } from '@fintekkers/ledger-models/node/wrappers/models/security/identifier';
 import field_pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/field_pb.js';
 import { getServiceConnection } from '$lib/grpc-auth';
 
@@ -33,7 +34,11 @@ export async function fetchPricesForSecurity(uuidStr: string, apiKey?: string): 
   request.setFrequency(PriceFrequencyProto.PRICE_FREQUENCY_DAILY);
 
   const filter = new PositionFilter();
-  filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidStr)));
+  // The wrapper's addObjectFilter signature only declares `Identifier`,
+  // but the runtime accepts any pack()-able object including UUID
+  // (used for SECURITY_ID filtering). Cast preserves the existing
+  // runtime behavior; tracked for an upstream signature widening.
+  filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidStr)) as unknown as Identifier);
   request.setSearchPriceInput(filter.toProto());
 
   const conn = getServiceConnection(apiKey);

--- a/src/routes/(authenticated)/data/cpi_index/+page.server.ts
+++ b/src/routes/(authenticated)/data/cpi_index/+page.server.ts
@@ -4,6 +4,7 @@ import { ZonedDateTime } from '@fintekkers/ledger-models/node/wrappers/models/ut
 import { getServiceConnection } from '$lib/grpc-auth';
 import { PositionFilter } from '@fintekkers/ledger-models/node/wrappers/models/position/positionfilter';
 import { UUID } from '@fintekkers/ledger-models/node/wrappers/models/utils/uuid';
+import type { Identifier } from '@fintekkers/ledger-models/node/wrappers/models/security/identifier';
 import field_pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/field_pb.js';
 import { SecurityService } from '@fintekkers/ledger-models/node/wrappers/services/security-service/SecurityService';
 import { IndexTypeProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/index/index_type_pb';
@@ -83,7 +84,9 @@ async function fetchPrices(uuidStr: string, apiKey?: string): Promise<CpiDataPoi
   request.setFrequency(PriceFrequencyProto.PRICE_FREQUENCY_DAILY);
 
   const filter = new PositionFilter();
-  filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidStr)));
+  // Wrapper signature too narrow (Identifier-only); runtime accepts UUID
+  // for SECURITY_ID. Cast pending an upstream signature widening.
+  filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidStr)) as unknown as Identifier);
   request.setSearchPriceInput(filter.toProto());
 
   const conn = getServiceConnection(apiKey);

--- a/src/routes/(authenticated)/data/prices/+page.server.ts
+++ b/src/routes/(authenticated)/data/prices/+page.server.ts
@@ -1,4 +1,5 @@
 import { FetchSecurity, FetchSecurityUniverse, type IdentifierTypeName } from '$lib/security';
+import type { Identifier } from '@fintekkers/ledger-models/node/wrappers/models/security/identifier';
 import { PriceService } from '@fintekkers/ledger-models/node/wrappers/services/price-service/PriceService';
 import { UUIDProto } from '@fintekkers/ledger-models/node/fintekkers/models/util/uuid_pb.js';
 import { ZonedDateTime } from '@fintekkers/ledger-models/node/wrappers/models/utils/datetime';
@@ -100,7 +101,10 @@ export async function load({ locals, request }) {
       securityDescription = `${sec.identifier} — ${sec.issuerName}${couponPart}${maturityPart}`.trim();
 
       const filter = new PositionFilter();
-      filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidHexToString(sec.uuidHex!))));
+      // Wrapper's addObjectFilter signature is too narrow (declares
+      // only Identifier); runtime accepts UUID for SECURITY_ID filters.
+      // Cast preserves runtime behavior; signature widening is upstream.
+      filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidHexToString(sec.uuidHex!))) as unknown as Identifier);
 
       const rawPrices = await priceService.search(now.toProto(), filter);
       prices = rawPrices

--- a/src/routes/contactus/+page.svelte
+++ b/src/routes/contactus/+page.svelte
@@ -78,7 +78,7 @@
                 <input
                     on:focus={() => handleFocus("firstname")}
                     on:change={(event) =>
-                        handleChange("firstname", event?.target.value)}
+                        handleChange("firstname", (event.target as HTMLInputElement).value)}
                     on:blur={() => handleBlur("firstname")}
                     id="firstname"
                     name="firstname"
@@ -105,7 +105,7 @@
                 <input
                     on:focus={() => handleFocus("lastname")}
                     on:change={(event) =>
-                        handleChange("lastname", event?.target.value)}
+                        handleChange("lastname", (event.target as HTMLInputElement).value)}
                     on:blur={() => handleBlur("lastname")}
                     id="lastname"
                     name="lastname"
@@ -131,7 +131,7 @@
                 <input
                     on:focus={() => handleFocus("email")}
                     on:change={(event) =>
-                        handleChange("email", event?.target.value)}
+                        handleChange("email", (event.target as HTMLInputElement).value)}
                     on:blur={() => handleBlur("email")}
                     id="email"
                     type="email"
@@ -157,7 +157,7 @@
                 <textarea
                     on:focus={() => handleFocus("message")}
                     on:change={(event) =>
-                        handleChange("message", event?.target.value)}
+                        handleChange("message", (event.target as HTMLTextAreaElement).value)}
                     on:blur={() => handleBlur("message")}
                     id="message"
                     name="message"

--- a/src/tests/prices-universal-identifier-e2e.test.ts
+++ b/src/tests/prices-universal-identifier-e2e.test.ts
@@ -28,6 +28,7 @@ import * as http from 'http';
 import * as path from 'path';
 
 import { FetchSecurity, FetchSecurityUniverse, clearUniverseCache } from '$lib/security';
+import type { Identifier } from '@fintekkers/ledger-models/node/wrappers/models/security/identifier';
 import { PriceService } from '@fintekkers/ledger-models/node/wrappers/services/price-service/PriceService';
 import { ZonedDateTime } from '@fintekkers/ledger-models/node/wrappers/models/utils/datetime';
 import { PositionFilter } from '@fintekkers/ledger-models/node/wrappers/models/position/positionfilter';
@@ -202,7 +203,7 @@ async function findValidatableSecurity(apiKeyArg: string): Promise<{ identifier:
 	const now = ZonedDateTime.now();
 	for (const cand of priceable.slice(0, 25)) {
 		const filter = new PositionFilter();
-		filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidHexToString(cand.uuidHex))));
+		filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidHexToString(cand.uuidHex))) as unknown as Identifier);
 		const raw = await priceService.search(now.toProto(), filter);
 		if (raw.length > 0) {
 			return { identifier: cand.identifier, identifierType: cand.identifierType, uuidHex: cand.uuidHex };
@@ -228,7 +229,7 @@ describe('Prices page load() — numbers match PriceService directly', () => {
 		const priceService = new PriceService(apiKey);
 		const now = ZonedDateTime.now();
 		const filter = new PositionFilter();
-		filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidHexToString(chosen.uuidHex))));
+		filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidHexToString(chosen.uuidHex))) as unknown as Identifier);
 		const directPrices = toPriceRows(await priceService.search(now.toProto(), filter));
 
 		// Page server load()
@@ -310,7 +311,7 @@ describe('Prices page load() — numbers match PriceService directly', () => {
 		// Direct PriceService stream
 		const priceService = new PriceService(apiKey);
 		const filter = new PositionFilter();
-		filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidHexToString(sec.uuidHex!))));
+		filter.addObjectFilter(FieldProto.SECURITY_ID, new UUID(UUID.fromString(uuidHexToString(sec.uuidHex!))) as unknown as Identifier);
 		const directPrices = toPriceRows(await priceService.search(ZonedDateTime.now().toProto(), filter));
 		expect(directPrices.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
In-repo follow-up to PR #137 (PR-A). Three categories that don't require cross-repo work; **−34 svelte-check errors (117 → 83)**.

> ⚠️ **PM-revoked-merge**: human review required. Do not auto-merge.

## What this fixes (per category)

| Fix | Errors | Pattern |
|---|---:|---|
| UUID vs Identifier | **−6** | `addObjectFilter(field, object: Identifier)` signature too narrow; runtime accepts `UUID` for SECURITY_ID. Cast at each of 6 call sites with a comment pointing at the upstream signature gap. |
| `keyof formError` | **−8** | Two orphan login components typed `fieldName: keyof formError`, which resolves to `string \| number \| symbol`. Loosened to `string`; `formError`'s `[x: string]: any` index signature accepts the lookup. |
| `Property 'value' does not exist on type 'EventTarget'` | **−5** | 5 `event?.target.value` accesses cast to `(event.target as HTMLInputElement).value` / `as HTMLTextAreaElement` per the rendered element. |
| **Drive-by**: −5 unused-var warnings | (warnings) | Dropped a `display` helper defined-but-never-referenced in both InputField components. Both files are currently orphan (unimported); cleaner to remove the dead code than carry the warning. |

## Files touched

- `src/lib/curvePrices.ts`
- `src/routes/(authenticated)/data/prices/+page.server.ts`
- `src/routes/(authenticated)/data/cpi_index/+page.server.ts`
- `src/tests/prices-universal-identifier-e2e.test.ts`
- `src/components/login/InputFieldText.svelte`
- `src/components/login/InputFieldTextArea.svelte`
- `src/routes/contactus/+page.svelte`

## Verification

| Check | Before | After |
|---|---:|---:|
| `npx svelte-check` errors | 117 | **83** (−34) |
| `npx svelte-check` warnings | 210 | 205 (−5) |
| `npx playwright test` | 22/22 | 22/22 |
| `npx vitest run` | 532 / 0 / 10 | 532 / 0 / 10 |

## Remaining svelte-check baseline

- **41 upstream `ledger-models` import-type errors** — cross-repo; on hold pending dispatch (user paused this earlier).
- **~42 long-tail errors** — component-specific, lower density.
- **Vitest worker OOM** on full runs — pre-existing; separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)