### PR TITLE
fix(tests): vitest worker OOM in qa-s8-transaction-limit

### DIFF
--- a/src/tests/qa-s8-transaction-limit.test.ts
+++ b/src/tests/qa-s8-transaction-limit.test.ts
@@ -49,14 +49,17 @@ async function transactionSearch(limit: number): Promise<{
 	req.setSearchTransactionInput(filter.toProto());
 	req.setLimit(limit);
 
-	const items: any[] = [];
+	// Count messages only — don't accumulate proto wrappers. limit=100000 used to
+	// OOM the vitest worker by pushing 100K heavy objects into an array we never
+	// inspected beyond `.length`.
+	let count = 0;
 	let error: string | undefined;
 
 	await new Promise<void>((resolve) => {
 		const stream = client.search(req);
 		stream.on('data', (resp: any) => {
 			const list = resp.getTransactionResponseList?.() ?? [];
-			list.forEach((t: any) => items.push(t));
+			count += list.length;
 		});
 		stream.on('end', () => resolve());
 		stream.on('error', (err: any) => {
@@ -65,7 +68,7 @@ async function transactionSearch(limit: number): Promise<{
 		});
 	});
 
-	return { count: items.length, error, limitSentToService: limit };
+	return { count, error, limitSentToService: limit };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The `limit=100000` test in `qa-s8-transaction-limit.test.ts` accumulated 100K proto wrappers into a JS array we never inspected beyond `.length`, OOM-ing the vitest worker mid-run.
- The service genuinely returns 100K results when asked, so swap the array for an incremental counter — same assertions, no heap blowup.
- This was the only error in the otherwise-green vitest baseline. After this change `npx vitest run` finishes 37/37 files, 534 tests, **zero unhandled errors**.

## Why now

Backlog item `vitest worker OOM` from `project_pre_merge_baseline_remediation`. With this in, vitest baseline is clean and can become a hard pre-merge gate without false positives.

## Test plan

- [x] `npx vitest run src/tests/qa-s8-transaction-limit.test.ts` — 7/7 pass
- [x] `npx vitest run` — 37/37 files, 534 tests, 0 errors
- [x] `npx svelte-check` — unchanged from main baseline (117/210, no regression)
- [ ] Reviewer: confirm the service genuinely caps somewhere reasonable (the test now logs `limit=100000 returned 100000 results` — that may itself be a backend follow-up to flag if 100K is *not* an intentional cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)