### PR TITLE
fix: thread apiKey to getTreasuryTransactions (/treasuries3 500)

### DIFF
--- a/src/routes/treasuries3/+page.server.ts
+++ b/src/routes/treasuries3/+page.server.ts
@@ -6,7 +6,10 @@ export async function load({ locals }) {
   // Filter for December 2025: get all transactions up to December 31, 2025
   // Then filter client-side for December 2025 only
   const endDate = new Date('2026-01-01T00:59:59');
-  const transactions = await getTreasuryTransactions(endDate);
+  // Thread apiKey through so the underlying Position/Search call goes via
+  // the broker's authenticated route instead of UNAUTHENTICATED-failing.
+  // Surfaced as a /treasuries3 500 in PR #137's reviewer checklist.
+  const transactions = await getTreasuryTransactions(endDate, locals.user?.apiKey);
 
   // Filter for December 2025 transactions, excluding bills
   const december2025NonBills: TreasuryTransaction[] = (transactions || []).filter((txn) => {

--- a/tests/e2e/treasuries3-loads.spec.ts
+++ b/tests/e2e/treasuries3-loads.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression for the /treasuries3 500 surfaced in PR #137's reviewer
+ * checklist. The page-server's load() called getTreasuryTransactions
+ * without threading locals.user?.apiKey, so the underlying gRPC search
+ * went out unauthenticated and the broker returned UNAUTHENTICATED —
+ * which the load() function re-threw, taking the whole page to a 500
+ * before render.
+ *
+ * After the fix, the page should either render the bond-activity table
+ * (December 2025 data is in the seed) OR the empty-state ("No bond
+ * activity ( bills) found for December 2025.") — but never 500.
+ *
+ * /treasuries3 is a top-level route (NOT under (authenticated)/), so
+ * `.auth-shell` is not present here. Assert against the page's own
+ * indicators: the H1 title, and either a data row or the .no-data
+ * block.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('/treasuries3 — page-server apiKey threading', () => {
+  test('/treasuries3 loads without 500 (apiKey threaded to getTreasuryTransactions)', async ({ page }) => {
+    const response = await page.goto('/treasuries3');
+
+    // 1. HTTP layer — the bug previously surfaced as a 500.
+    expect(response, 'GET /treasuries3 returns a response').not.toBeNull();
+    const status = response!.status();
+    expect(status, 'no 500 / no 5xx after apiKey threading').toBeLessThan(500);
+
+    // 2. Render layer — the page's own H1 is the cheap "page rendered"
+    // signal that doesn't depend on the seed having data. Not an exact
+    // match because the heading text contains regex-special chars.
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Bond Activity.*December 2025/ }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // 3. Either the table OR the empty-state is acceptable — both prove
+    // the page-server's load() returned cleanly. The seed contents are
+    // backend-driven and can change without breaking this assertion.
+    const table = page.locator('table.bond-activity-table');
+    const emptyState = page.locator('.no-data');
+    const hasTable = await table.isVisible().catch(() => false);
+    const hasEmptyState = await emptyState.isVisible().catch(() => false);
+    expect(
+      hasTable || hasEmptyState,
+      'either the table OR the empty-state is rendered',
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The `/treasuries3` page-server's `load()` called `getTreasuryTransactions(endDate)` without threading `locals.user?.apiKey` through. The underlying gRPC search went out unauthenticated, the broker returned `UNAUTHENTICATED`, and the load function re-threw — taking the whole page to a **500 before render**.

The wrapper already accepts an optional `apiKey` and uses `getServiceConnection(apiKey)` internally; the page-server just wasn't passing it. **One-line fix** in `src/routes/treasuries3/+page.server.ts:9`.

## Why this matters now

Flagged on [PR #137](https://github.com/FinTekkers/ui-service/pull/137)'s reviewer checklist as the gating concern for **visually verifying the TENOR string-parse work** that PR landed. Without `/treasuries3` loading, the rendered `Tenor` column can't be inspected end-to-end. This fix unblocks that verification.

Pre-existing on `main` — not caused by recent work.

## Test plan

- [x] `npx playwright test tests/e2e/treasuries3-loads.spec.ts` → 1/1 pass
- [x] `npx playwright test` (full) → **29/29** pass (was 28; +1 regression case)
- [x] `npx svelte-check` → unchanged from main baseline (83/205)
- [x] `npx vitest run` → 534/534 (unchanged baseline)
- [ ] Reviewer: visually confirm `/treasuries3` renders bond activity for December 2025 + the `Tenor` column shows `Y/M` formatting from PR #137's parse work.

The new e2e regression case asserts the page returns `< 500`, the H1 title renders, and **either the data table OR the empty-state block is visible** — both prove `load()` returned cleanly, without coupling the test to the seed having December 2025 data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)