### PR TITLE
PortfolioFilter rollout: /data/transactions migration (Phase 3 of #226, PR-B)

### DIFF
--- a/src/components/widgets/TransactionSelect.svelte
+++ b/src/components/widgets/TransactionSelect.svelte
@@ -10,10 +10,11 @@
    * (PositionFilterOperator names, post-#229) so users moving between
    * the two pages don't have to relearn the filter shape.
    *
-   * portfolioId is preserved across re-submits via buildFilterUrl's
-   * inheritKeys (matches the #220-class guard in PositionSelect): when
-   * the user lands here from /data/portfolios with ?portfolioId=…, that
-   * scope survives the Filter button click.
+   * portfolio scope flows through PortfolioFilter (Phase 3 PR-B of
+   * #226). The form is authoritative — portfolioId is no longer in
+   * buildFilterUrl's inheritKeys; the page-server hydrates the form's
+   * initial state from the inbound URL so re-submits preserve scope,
+   * matching PositionSelect's PR #146 wiring.
    *
    * The filter is a coupled (date, operator) pair — emit both or neither
    * so the page-server doesn't apply a half-formed filter (matches the
@@ -22,9 +23,22 @@
   import { onMount } from "svelte";
   import { buildFilterUrl } from "$lib/filters/urlState";
   import DateFilter from "../filters/DateFilter.svelte";
+  import PortfolioFilter from "../filters/PortfolioFilter.svelte";
+  import type { PortfolioOption } from "../filters/PortfolioFilter.svelte";
+
+  // Phase 3 of #226 PR-B: PortfolioFilter primitive. Page-server
+  // provides the (id, name) universe + the resolved name for the
+  // inbound URL portfolioId. Both flow through here as defaults so
+  // the form starts populated when the user lands via /data/portfolios
+  // (Txns link) or any other portfolioId-bearing URL.
+  export let portfolioUniverse: readonly PortfolioOption[] = [];
+  export let initialPortfolioId: string = "";
+  export let initialPortfolioName: string = "";
 
   let tradeDateInput: string = "";
   let tradeDateOperator: string = "";
+  let portfolioIdInput: string = initialPortfolioId;
+  let portfolioNameInput: string = initialPortfolioName;
 
   function fetchTransactions() {
     if (typeof window === "undefined") return;
@@ -35,17 +49,28 @@
     const tradeDateOperatorOverride =
       trimmedTradeDate && tradeDateOperator ? tradeDateOperator : undefined;
 
+    // Portfolio scope is now form-driven via PortfolioFilter (#226 PR-B).
+    // Trimmed-empty input emits null (explicit removal — the user
+    // cleared the autocomplete) so a stale bookmark doesn't ride
+    // through. portfolioId is no longer in inheritKeys for the same
+    // reason: the form owns it now, so inherit + override would be
+    // redundant. Mirrors PositionSelect's PR #146 wiring.
+    const trimmedPortfolioId = portfolioIdInput.trim();
+    const portfolioIdOverride = trimmedPortfolioId === '' ? null : trimmedPortfolioId;
+
     const url = buildFilterUrl(
       "/data/transactions",
       new URLSearchParams(window.location.search),
       {
         tradeDate: tradeDateOverride,
         tradeDateOperator: tradeDateOperatorOverride,
+        portfolioId: portfolioIdOverride,
       },
-      // Carry through the inbound portfolio scope so the Filter button
-      // doesn't silently widen a portfolio-scoped view back to the
-      // global transaction list (#220-class guard).
-      ["portfolioId"],
+      // No more inheritKeys — every form field is form-driven now,
+      // including portfolioId. The original #220-class concern is
+      // addressed by initial-state hydration from the page-server,
+      // not URL passthrough.
+      [],
     );
 
     window.location.href = url;
@@ -66,6 +91,16 @@
 </script>
 
 <div class="transaction-select-container mt-6 mx-10 flex flex-col sm:flex-row gap-2">
+  <div class="text-white portfolio-filter-cell">
+    <h4>Portfolio:</h4>
+    <PortfolioFilter
+      bind:portfolioId={portfolioIdInput}
+      bind:portfolioName={portfolioNameInput}
+      universe={portfolioUniverse}
+      inputClass="transaction-select-input text-black"
+      inputId="transaction-portfolio-input"
+    />
+  </div>
   <div class="text-white date-filter-cell">
     <h4>Trade Date Filter:</h4>
     <DateFilter

--- a/src/routes/(authenticated)/data/transactions/+page.server.ts
+++ b/src/routes/(authenticated)/data/transactions/+page.server.ts
@@ -1,5 +1,6 @@
 import { FetchTransaction, FetchTransactionByPortfolio } from "$lib/transactions";
 import { deleteEntity } from '$lib/entity-delete';
+import { FetchPortfolioUniverse, type PortfolioUniverseEntry } from "$lib/portfolios";
 
 /** @type {import('../../../../../.svelte-kit/types/src/routes').PageServerLoad} */
 export async function load({ locals, url }) {
@@ -10,6 +11,18 @@ export async function load({ locals, url }) {
   // dump every transaction across every portfolio onto the page.
   const portfolioId = url.searchParams.get('portfolioId');
   const apiKey = locals.user?.apiKey;
+
+  // Phase 3 of #226 (PR-B): PortfolioFilter primitive needs the
+  // (id, name) universe + the resolved display name for the inbound
+  // portfolioId. Mirrors the /data/positions wiring shipped in PR #146.
+  // The universe is cached for 5 min in $lib/portfolios so the
+  // per-load cost is bounded. Empty universe (e.g. portfolio service
+  // unavailable) leaves the autocomplete empty but doesn't break the
+  // page.
+  const portfolioUniverse: PortfolioUniverseEntry[] =
+    await FetchPortfolioUniverse(apiKey).catch(() => []);
+  const portfolioName =
+    portfolioId && portfolioUniverse.find((p) => p.portfolioId === portfolioId)?.portfolioName || '';
 
   // Phase 3 PR-B of #226: optional tradeDate filter. URL convention
   // mirrors /data/positions exactly (?tradeDate=YYYY-MM-DD&
@@ -27,6 +40,8 @@ export async function load({ locals, url }) {
   return {
     transactions,
     portfolioId: portfolioId || null,
+    portfolioName,
+    portfolioUniverse,
     user: locals.user
   };
 }

--- a/src/routes/(authenticated)/data/transactions/+page.svelte
+++ b/src/routes/(authenticated)/data/transactions/+page.svelte
@@ -48,7 +48,11 @@
   }
 </script>
 
-<TransactionSelect />
+<TransactionSelect
+  portfolioUniverse={data.portfolioUniverse ?? []}
+  initialPortfolioId={data.portfolioId ?? ''}
+  initialPortfolioName={data.portfolioName ?? ''}
+/>
 
 {#if deleteSuccess}
   <div class="success-banner">{deleteSuccess}</div>

--- a/tests/e2e/portfolio-filter-transactions.spec.ts
+++ b/tests/e2e/portfolio-filter-transactions.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Phase 3 of second-brain#226 (PR-B): PortfolioFilter primitive on
+ * /data/transactions, completing the rollout started in PR #146
+ * (PR-A migrated /data/positions). Two cases mirror the
+ * /data/positions e2e (tests/e2e/portfolio-filter.spec.ts):
+ *
+ *   1. Autocomplete: typing 'Federal' surfaces the SOMA suggestion;
+ *      selecting it sets ?portfolioId=<uuid> on Filter.
+ *
+ *   2. Inbound URL hydration: loading /data/transactions?portfolioId=<uuid>
+ *      populates the PortfolioFilter input with the resolved portfolio
+ *      name (Federal Reserve SOMA Holdings, not the raw UUID).
+ *
+ * Hardening matches PR #147 (positions-side):
+ *   - waitForLoadState('networkidle') before typing so the universe
+ *     data has finished loading.
+ *   - 10s timeout on the suggestion-visible assertion.
+ *
+ * Assumes the SOMA seed is loaded — same dependency as the existing
+ * portfolio-soma-transactions / portfolio-soma-positions specs.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const SOMA_NAME = 'Federal Reserve SOMA Holdings';
+
+async function resolveSomaPortfolioId(page: Page): Promise<string> {
+  await page.goto('/data/portfolios');
+  const link = page.getByRole('link', { name: SOMA_NAME });
+  const href = await link.getAttribute('href');
+  expect(href).toMatch(/portfolioId=[0-9a-f-]{36}/);
+  return new URL(href!, page.url()).searchParams.get('portfolioId')!;
+}
+
+test.describe('/data/transactions PortfolioFilter (#226 Phase 3 PR-B)', () => {
+  test('typing "Federal" suggests SOMA; selecting sets ?portfolioId on Filter', async ({ page }) => {
+    const expectedPortfolioId = await resolveSomaPortfolioId(page);
+
+    await page.goto('/data/transactions');
+    const portfolioInput = page.locator('#transaction-portfolio-input');
+    await expect(portfolioInput).toBeVisible({ timeout: 15_000 });
+    await expect(portfolioInput, 'starts empty when URL has no portfolioId').toHaveValue('');
+    // Wait for universe data to land before typing — the universe is
+    // a page-server prop and a fast `.fill()` against an empty list
+    // produces zero suggestions. Same hardening shipped in PR #147
+    // for the positions-side test.
+    await page.waitForLoadState('networkidle');
+
+    await portfolioInput.click();
+    await portfolioInput.fill('Federal');
+
+    const suggestion = page.locator('.suggestion', { hasText: SOMA_NAME });
+    await expect(suggestion, 'autocomplete surfaces SOMA').toBeVisible({ timeout: 10_000 });
+
+    await suggestion.click();
+    await expect(portfolioInput).toHaveValue(SOMA_NAME);
+
+    // Click Filter — URL re-emits with portfolioId set to SOMA.
+    await page.getByRole('button', { name: /^Filter$/ }).click();
+    await page.waitForURL(/\/data\/transactions\?.*portfolioId=/, { timeout: 10_000 });
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('portfolioId'), 'portfolioId emitted from selection')
+      .toBe(expectedPortfolioId);
+  });
+
+  test('?portfolioId=<uuid> hydrates the input with the resolved name', async ({ page }) => {
+    const portfolioId = await resolveSomaPortfolioId(page);
+
+    await page.goto(`/data/transactions?portfolioId=${portfolioId}`);
+
+    const portfolioInput = page.locator('#transaction-portfolio-input');
+    await expect(portfolioInput, 'page-server resolves UUID → portfolio name')
+      .toHaveValue(SOMA_NAME, { timeout: 15_000 });
+
+    // Round-trip through Filter — the form is now authoritative for
+    // portfolioId (no inheritKeys). Should re-emit the same UUID.
+    await page.getByRole('button', { name: /^Filter$/ }).click();
+    await page.waitForURL(/\/data\/transactions\?.*portfolioId=/, { timeout: 10_000 });
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('portfolioId'), 'form re-emits the inbound portfolioId')
+      .toBe(portfolioId);
+  });
+});


### PR DESCRIPTION
Completes the [PortfolioFilter](https://github.com/FinTekkers/ui-service/pull/146) primitive rollout. PR-A migrated `/data/positions`; this PR-B migrates `/data/transactions`. Together they close the PortfolioFilter slice of [second-brain#226](https://github.com/FinTekkers/second-brain/issues/226) Phase 3.

## Summary

Mirrors PR #146 exactly — same migration shape, same hardening applied to the new e2e cases (PR #147's `networkidle` + 10s timeout pattern).

## Modified

- **`src/components/widgets/TransactionSelect.svelte`** — adds three new props (`portfolioUniverse`, `initialPortfolioId`, `initialPortfolioName`); renders `<PortfolioFilter>` at the front of the filter row. **`portfolioId` is now a form override** (dropped from `inheritKeys`); empty input emits `null` so explicit clear removes the param. The original [#220](https://github.com/FinTekkers/second-brain/issues/220)-class concern stays addressed via initial-state hydration from page-server data.
- **`src/routes/(authenticated)/data/transactions/+page.server.ts`** — `load()` awaits `FetchPortfolioUniverse` (cheap with the existing 5-min TTL cache) and resolves the inbound `portfolioId` → display name. Returns universe + resolved name alongside existing fields.
- **`src/routes/(authenticated)/data/transactions/+page.svelte`** — threads `data.portfolioUniverse / data.portfolioId / data.portfolioName` into `TransactionSelect`.

## New e2e tests

`tests/e2e/portfolio-filter-transactions.spec.ts` — 2 cases mirroring the positions-side suite:
1. Type `Federal` → SOMA appears → click → `?portfolioId=<uuid>` on Filter.
2. `?portfolioId=<uuid>` hydrates the input with the resolved name.

Both tests apply [PR #147](https://github.com/FinTekkers/ui-service/pull/147)'s hardening from day one — `waitForLoadState('networkidle')` before typing, 10s timeout on suggestion visibility. **No autocomplete-render-race flake** to chase later.

## Out of scope (separate Phase 3 dispatches)

- `MeasureMultiselectFilter` — positions-only consumer.
- `HideZerosToggle` — positions-only consumer.
- `/data/securities` does not have a `portfolioId` concept — not in scope.

## Test plan

- [x] `npx svelte-check` — **83 / 205**, unchanged from `main` baseline. No new errors.
- [x] `npx vitest run` — **38/38** files, **544/544** passing.
- [x] `npx playwright test` — **33/33** passing on first run (was 31; +2 from this PR).

## Constraints checked

- No new primitives extracted (`PortfolioFilter` exists from PR #146).
- `/data/positions`, `/data/securities`, `/data/portfolios` untouched.
- No backend RPC gap (`FetchPortfolioUniverse` already shipped in PR #146).
- No `ledger-models` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)