### PR TITLE
MeasureMultiselectFilter + HideZerosToggle primitives + /data/positions migration (Phase 3 of #226, complete)

### DIFF
--- a/src/components/filters/HideZerosToggle.svelte
+++ b/src/components/filters/HideZerosToggle.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  /**
+   * Phase 3 of second-brain#226 — seventh and final composable filter
+   * primitive. A labeled checkbox that hides rows whose every measure
+   * is zero. Single in-tree consumer today: PositionSelect.svelte.
+   *
+   * Factored out for consistency with the other Phase 3 primitives —
+   * the entire filter row on /data/positions is now a sequence of
+   * small composable parts. No URL knowledge; the page consumer
+   * owns ?hideZeros=true emission and parsing.
+   */
+
+  // Two-way binding. URL convention is "true" / absent (no false on
+  // the URL — same as the existing /data/positions emit pattern).
+  export let value: boolean = false;
+
+  export let label: string = 'Hide zero values';
+  export let id: string = 'hide-zeros-toggle';
+</script>
+
+<label class="inline-flex items-center cursor-pointer" for={id}>
+  <input
+    {id}
+    type="checkbox"
+    bind:checked={value}
+    class="form-checkbox h-4 w-4 text-green-600"
+  />
+  <span class="ml-2">{label}</span>
+</label>

--- a/src/components/filters/HideZerosToggle.test.ts
+++ b/src/components/filters/HideZerosToggle.test.ts
@@ -1,0 +1,44 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+import HideZerosToggle from './HideZerosToggle.svelte';
+
+describe('HideZerosToggle', () => {
+  test('renders an unchecked checkbox by default', () => {
+    const { container } = render(HideZerosToggle);
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(false);
+  });
+
+  test('value=true initializes the checkbox as checked', () => {
+    const { container } = render(HideZerosToggle, { props: { value: true } });
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  test('default label reads "Hide zero values"', () => {
+    const { container } = render(HideZerosToggle);
+    expect(container.textContent).toContain('Hide zero values');
+  });
+
+  test('label prop overrides the default text', () => {
+    const { container } = render(HideZerosToggle, { props: { label: 'Hide zeros' } });
+    expect(container.textContent).toContain('Hide zeros');
+    expect(container.textContent).not.toContain('Hide zero values');
+  });
+
+  test('id prop reaches the input element (label htmlFor association)', () => {
+    const { container } = render(HideZerosToggle, { props: { id: 'custom-toggle' } });
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.id).toBe('custom-toggle');
+    const label = container.querySelector('label') as HTMLLabelElement;
+    expect(label.htmlFor).toBe('custom-toggle');
+  });
+
+  test('two-way bind: clicking the checkbox flips the bound value', async () => {
+    const { container } = render(HideZerosToggle, { props: { value: false } });
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+  });
+});

--- a/src/components/filters/MeasureMultiselectFilter.svelte
+++ b/src/components/filters/MeasureMultiselectFilter.svelte
@@ -1,0 +1,127 @@
+<script lang="ts" context="module">
+  /**
+   * Phase 3 of second-brain#226 — sixth composable filter primitive.
+   * Multi-select dropdown for picking position-measure names. The
+   * external API speaks in proto enum names ('DIRECTED_QUANTITY',
+   * 'MARKET_VALUE', ...); the dropdown renders friendly title-case
+   * labels via DEFAULT_MEASURE_LABELS so the user never sees raw
+   * upper-snake-case names.
+   *
+   * Single in-tree consumer today: PositionSelect.svelte. Factored
+   * out for consistency with the other Phase 3 primitives — same API
+   * shape (bind:value, supportedX prop, labels override) makes the
+   * form a sequence of small composable parts instead of one
+   * 300-line god-component.
+   *
+   * No URL knowledge — the page consumer owns ?measures=… emission
+   * and parsing. No proto-name validation either; the URL convention
+   * is already proto names, so a malformed URL just produces an
+   * unselected option in the dropdown.
+   */
+  import measure_pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/measure_pb.js';
+  const { MeasureProto } = measure_pkg;
+
+  // Valuation-only measures are excluded by default — they require a
+  // RunValuation call rather than the Position search the basic
+  // /data/positions page hits, so showing them in the multiselect
+  // would surface a silent no-op. Consumers that want them (a future
+  // valuations page) can pass a different supportedMeasures list.
+  const VALUATION_ONLY_MEASURES = new Set([
+    'PRESENT_VALUE_CASHFLOWS',
+    'PRESENT_VALUE',
+    'REAL_YIELD',
+    'INFLATION_ADJUSTED_PRINCIPAL',
+    'DISCOUNT_MARGIN',
+    'SPREAD_DURATION',
+  ]);
+
+  /**
+   * The default proto-name allowlist: every MeasureProto enum entry
+   * minus the valuation-only set. Drives the dropdown options when
+   * the consumer doesn't pass a custom `supportedMeasures` prop.
+   */
+  export const DEFAULT_MEASURE_NAMES: readonly string[] = Object.keys(MeasureProto)
+    .filter((k) => typeof (MeasureProto as Record<string, unknown>)[k] === 'number')
+    .filter((k) => !VALUATION_ONLY_MEASURES.has(k));
+
+  function titleCase(name: string): string {
+    return name
+      .split('_')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+      .join(' ');
+  }
+
+  /** Friendly per-measure labels. Override individual entries via the `labels` prop. */
+  export const DEFAULT_MEASURE_LABELS: Record<string, string> = Object.fromEntries(
+    DEFAULT_MEASURE_NAMES.map((n) => [n, titleCase(n)]),
+  );
+</script>
+
+<script lang="ts">
+  import MultiSelect from 'svelte-multiselect';
+
+  // Two-way binding — array of proto enum names. Empty array means
+  // "no measures selected" (the URL convention drops the param).
+  export let value: string[] = [];
+
+  // Proto-name allowlist for the dropdown. Default = MeasureProto
+  // keys minus valuation-only.
+  export let supportedMeasures: readonly string[] = DEFAULT_MEASURE_NAMES;
+
+  // Per-name label override. Falls back to DEFAULT_MEASURE_LABELS,
+  // which falls back to the proto name verbatim if neither map has
+  // an entry.
+  export let labels: Partial<Record<string, string>> = {};
+
+  // Class pass-through and DOM hooks (matches IdentifierFilter
+  // conventions).
+  export let containerClass: string = '';
+  export let id: string = 'measure-multiselect';
+  export let placeholder: string = 'Select measures...';
+
+  $: resolvedLabels = { ...DEFAULT_MEASURE_LABELS, ...labels };
+
+  // Build the MultiSelect's option-label list + a label↔name lookup
+  // for the change handler. The dropdown speaks display labels; the
+  // primitive's external API speaks proto names.
+  $: optionLabels = supportedMeasures.map((name) => resolvedLabels[name] ?? name);
+  $: labelToName = Object.fromEntries(
+    supportedMeasures.map((name) => [resolvedLabels[name] ?? name, name]),
+  );
+
+  // Internal MultiSelect state holds the display labels. Reactive
+  // sync from `value` (proto names) → `selected` (labels) handles
+  // initial-state hydration and external updates. The equality guard
+  // avoids a feedback loop with the on:change handler that writes
+  // back to `value`. Initialized empty here and populated by the $:
+  // block below — at instance-init time `resolvedLabels` hasn't been
+  // computed yet, so a synchronous `value.map(...)` initializer
+  // would dereference undefined.
+  let selected: string[] = [];
+  $: {
+    const expected = value.map((name) => resolvedLabels[name] ?? name);
+    if (
+      expected.length !== selected.length ||
+      expected.some((label, i) => label !== selected[i])
+    ) {
+      selected = expected;
+    }
+  }
+
+  function handleChange() {
+    const next = selected.map((label) => labelToName[label]).filter((n): n is string => Boolean(n));
+    if (next.length !== value.length || next.some((v, i) => v !== value[i])) {
+      value = next;
+    }
+  }
+</script>
+
+<div class={containerClass}>
+  <MultiSelect
+    {id}
+    options={optionLabels}
+    bind:selected
+    on:change={handleChange}
+    {placeholder}
+  />
+</div>

--- a/src/components/filters/MeasureMultiselectFilter.test.ts
+++ b/src/components/filters/MeasureMultiselectFilter.test.ts
@@ -1,0 +1,98 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+import MeasureMultiselectFilter, {
+  DEFAULT_MEASURE_NAMES,
+  DEFAULT_MEASURE_LABELS,
+} from './MeasureMultiselectFilter.svelte';
+
+describe('MeasureMultiselectFilter', () => {
+  test('renders a single combobox/multiselect input', () => {
+    const { container } = render(MeasureMultiselectFilter);
+    // svelte-multiselect renders an `<input>` for the search field
+    // inside the `<ul>` widget. One input is enough for a smoke test.
+    expect(container.querySelector('input')).toBeInTheDocument();
+  });
+
+  test('DEFAULT_MEASURE_NAMES exports the runtime allowlist (proto names, valuation-only excluded)', () => {
+    // Sanity: the four measures the in-tree consumer (PortfolioGrid)
+    // hard-emits are all in the default set.
+    expect(DEFAULT_MEASURE_NAMES).toEqual(expect.arrayContaining([
+      'DIRECTED_QUANTITY',
+      'MARKET_VALUE',
+      'PROFIT_LOSS',
+      'CURRENT_YIELD',
+      'YIELD_TO_MATURITY',
+    ]));
+    // Valuation-only entries are filtered out (rendering them would
+    // surface a silent no-op in the position search path).
+    expect(DEFAULT_MEASURE_NAMES).not.toEqual(expect.arrayContaining([
+      'PRESENT_VALUE',
+      'PRESENT_VALUE_CASHFLOWS',
+      'REAL_YIELD',
+      'INFLATION_ADJUSTED_PRINCIPAL',
+      'DISCOUNT_MARGIN',
+      'SPREAD_DURATION',
+    ]));
+  });
+
+  test('DEFAULT_MEASURE_LABELS title-cases proto names', () => {
+    expect(DEFAULT_MEASURE_LABELS.DIRECTED_QUANTITY).toBe('Directed Quantity');
+    expect(DEFAULT_MEASURE_LABELS.MARKET_VALUE).toBe('Market Value');
+    expect(DEFAULT_MEASURE_LABELS.YIELD_TO_MATURITY).toBe('Yield To Maturity');
+  });
+
+  test('containerClass / id pass through to the rendered nodes', () => {
+    const { container } = render(MeasureMultiselectFilter, {
+      props: { containerClass: 'my-wrapper cls', id: 'custom-id' },
+    });
+    // Locate the wrapper div by one of the pass-through class tokens.
+    // (testing-library's `container` is the test renderer's host;
+    // the actual wrapper sits one level deeper in some setups.)
+    const wrapper = container.querySelector('.my-wrapper') as HTMLElement;
+    expect(wrapper, 'containerClass renders as a wrapper class').not.toBeNull();
+    expect(wrapper.className).toContain('cls');
+    // The id is forwarded into svelte-multiselect's outer node.
+    expect(container.querySelector('#custom-id')).not.toBeNull();
+  });
+
+  test('initial value (proto names) renders friendly-labeled chips', () => {
+    const { container } = render(MeasureMultiselectFilter, {
+      props: { value: ['DIRECTED_QUANTITY', 'MARKET_VALUE'] },
+    });
+    // svelte-multiselect renders selected items as <li> elements with
+    // the friendly label text (DEFAULT_MEASURE_LABELS lookup).
+    const text = container.textContent ?? '';
+    expect(text).toContain('Directed Quantity');
+    expect(text).toContain('Market Value');
+  });
+
+  test('supportedMeasures restricts the dropdown to a subset', async () => {
+    const { container } = render(MeasureMultiselectFilter, {
+      props: { supportedMeasures: ['DIRECTED_QUANTITY'] },
+    });
+    // The hidden form input mirrors the option list svelte-multiselect
+    // exposes; assert that the only label visible in the rendered
+    // option-set text is "Directed Quantity". (Easier than poking the
+    // library's internals.)
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.focus(input);
+    // After focus the dropdown is open; the rendered text should
+    // include exactly one option label.
+    const text = container.textContent ?? '';
+    expect(text).toContain('Directed Quantity');
+    expect(text).not.toContain('Market Value');
+  });
+
+  test('labels prop overrides specific friendly labels', () => {
+    const { container } = render(MeasureMultiselectFilter, {
+      props: {
+        value: ['DIRECTED_QUANTITY'],
+        labels: { DIRECTED_QUANTITY: 'Quantity' },
+      },
+    });
+    const text = container.textContent ?? '';
+    expect(text).toContain('Quantity');
+    // The override beats the default 'Directed Quantity' label.
+    expect(text).not.toContain('Directed Quantity');
+  });
+});

--- a/src/components/widgets/PositionSelect.svelte
+++ b/src/components/widgets/PositionSelect.svelte
@@ -2,7 +2,6 @@
   import MultiSelect from "svelte-multiselect";
 
   import pkg from "@fintekkers/ledger-models/node/fintekkers/models/position/field_pb.js";
-  import measure_pkg from "@fintekkers/ledger-models/node/fintekkers/models/position/measure_pb.js";
   import position_pkg from "@fintekkers/ledger-models/node/fintekkers/models/position/position_pb.js";
   import { onMount } from "svelte";
   import { buildFilterUrl } from "$lib/filters/urlState";
@@ -10,6 +9,8 @@
   import DateFilter from "../filters/DateFilter.svelte";
   import PortfolioFilter from "../filters/PortfolioFilter.svelte";
   import type { PortfolioOption } from "../filters/PortfolioFilter.svelte";
+  import MeasureMultiselectFilter from "../filters/MeasureMultiselectFilter.svelte";
+  import HideZerosToggle from "../filters/HideZerosToggle.svelte";
   // Browser-safe import (security.ts pulls in @grpc/grpc-js).
   import {
     IDENTIFIER_TYPE_NAMES,
@@ -17,21 +18,6 @@
   } from "$lib/securityFilterTypes";
 
   const { FieldProto } = pkg;
-
-  const { MeasureProto } = measure_pkg;
-
-  const VALUATION_ONLY_MEASURES = new Set([
-    'PRESENT_VALUE_CASHFLOWS',
-    'PRESENT_VALUE',
-    'REAL_YIELD',
-    'INFLATION_ADJUSTED_PRINCIPAL',
-    'DISCOUNT_MARGIN',
-    'SPREAD_DURATION',
-  ]);
-
-  const positionMeasureOptions = Object.keys(MeasureProto)
-    .filter(k => !VALUATION_ONLY_MEASURES.has(k))
-    .map(formatName);
 
   const { PositionTypeProto, PositionViewProto } = position_pkg;
 
@@ -117,7 +103,10 @@
         positionView: selectedPositionView.map(unformatName).join(","),
         positionType: selectedPositionType.map(unformatName).join(","),
         fields: selectedFields.map(unformatName).join(","),
-        measures: selectedMeasures.map(unformatName).join(","),
+        // selectedMeasures is already proto names (the
+        // MeasureMultiselectFilter primitive's external API; the
+        // friendly labels live inside that component).
+        measures: selectedMeasures.join(","),
         identifier: trimmedIdentifier || undefined,
         identifierType: trimmedIdentifier ? identifierType : undefined,
         // No legacy ?cusip= override needed: a stale ?cusip= bookmark
@@ -157,7 +146,8 @@
       }
 
       if (selectedMeasuresFromUrl) {
-        selectedMeasures = selectedMeasuresFromUrl.split(",").map(formatName);
+        // URL value is already proto names — no conversion needed.
+        selectedMeasures = selectedMeasuresFromUrl.split(",");
       }
 
       if (selectedPositionTypeFromUrl) {
@@ -229,14 +219,11 @@
     </div>
     <div class="text-white">
       <h4>Measures:</h4>
-      <div class="multiselect-wrapper text-black">
-        <MultiSelect
-          id="measures-multiselect"
-          options={positionMeasureOptions}
-          placeholder="Select measures..."
-          bind:selected={selectedMeasures}
-        />
-      </div>
+      <MeasureMultiselectFilter
+        id="measures-multiselect"
+        bind:value={selectedMeasures}
+        containerClass="multiselect-wrapper text-black"
+      />
     </div>
     <div class="text-white">
       <h4>Position Type:</h4>
@@ -315,15 +302,8 @@
       </button>
     </div>
   </div>
-  <div class="px-10 mt-2">
-    <label class="inline-flex items-center cursor-pointer">
-      <input
-        type="checkbox"
-        bind:checked={hideZeros}
-        class="form-checkbox h-4 w-4 text-green-600"
-      />
-      <span class="ml-2 text-white">Hide zeros</span>
-    </label>
+  <div class="px-10 mt-2 text-white">
+    <HideZerosToggle bind:value={hideZeros} label="Hide zeros" />
   </div>
 </div>
 


### PR DESCRIPTION
**Closes the primitive-extraction slice of [second-brain#226](https://github.com/FinTekkers/second-brain/issues/226).** Two final primitives — both positions-only consumers — batched into one PR.

## New primitives

- **`MeasureMultiselectFilter.svelte`** (127 lines): multi-select dropdown for position-measure proto names. External API speaks proto names (`DIRECTED_QUANTITY`, `MARKET_VALUE`, …); the dropdown renders friendly title-case labels via `DEFAULT_MEASURE_LABELS`. Default `supportedMeasures` = `MeasureProto` keys minus the **valuation-only set** (`PRESENT_VALUE_CASHFLOWS`, `PRESENT_VALUE`, `REAL_YIELD`, `INFLATION_ADJUSTED_PRINCIPAL`, `DISCOUNT_MARGIN`, `SPREAD_DURATION`) — those require a `RunValuation` call rather than position search, so surfacing them in this dropdown would yield silent no-ops.
- **`HideZerosToggle.svelte`** (29 lines): labeled checkbox bound to a boolean. Tiny — the value is consistency with the rest of the filter row, not size savings.

## Migration in `PositionSelect.svelte`

- Inline `<MultiSelect bind:selected={selectedMeasures}>` with locally-derived `positionMeasureOptions` → `<MeasureMultiselectFilter bind:value={selectedMeasures}>`. The local `VALUATION_ONLY_MEASURES` set + filter logic moves into the primitive.
- Inline checkbox + label → `<HideZerosToggle bind:value={hideZeros} />`.
- **`selectedMeasures` internal data shape changes** from formatted display strings (`"Directed Quantity"`) to proto enum names (`"DIRECTED_QUANTITY"`). The URL convention was already proto names — `PortfolioGrid` emits them directly; the form was `formatName`/`unformatName`-converting at the URL boundary. So this is a pure simplification: form holds proto names end-to-end, URL emit/load drops the conversion for measures.

## On the UI-side label map

Friendly per-measure labels (`DIRECTED_QUANTITY → 'Directed Quantity'`) are still UI-side because `MeasureProto` in ledger-models doesn't ship descriptions today. Same call-out as #229's date-operator labels — moving these upstream is a follow-up if/when ledger-models adds Measure descriptions. Lower priority than the `PositionFilterOperator` one (measures are positions-only and the rendered labels are stable).

## Tests

- `MeasureMultiselectFilter.test.ts` — 7 cases mirroring `IdentifierFilter.test.ts` shape (default options sanity, label map, container/id pass-through, initial value rendering, `supportedMeasures` restriction, labels override).
- `HideZerosToggle.test.ts` — 6 cases (default unchecked, `value=true` init, default label, label override, id forwarding + `htmlFor` association, two-way bind on click).

## Test plan

- [x] `npx svelte-check` — **83 / 205**, unchanged from `main` baseline.
- [x] `npx vitest run` — **40/40 files, 557/557 passing** (+13 from new tests).
- [x] `npx playwright test` — **33/33 passing** — no behavioural change visible to users.

## #226 Phase 3 — complete

All originally-planned primitives extracted:

| Primitive | PR |
|---|---|
| IdentifierFilter | #130 |
| DateFilter | #135 |
| SecurityTypeFilter, AssetClassFilter | #136 |
| PortfolioFilter (PR-A: positions) | #146 |
| PortfolioFilter (PR-B: transactions) | #148 |
| **MeasureMultiselectFilter, HideZerosToggle** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)