### PR TITLE
fix(#221): /data/portfolios shows all portfolios — drop SOMA-only filter + per-row guard

### DIFF
--- a/src/components/widgets/PortfolioGrid.svelte
+++ b/src/components/widgets/PortfolioGrid.svelte
@@ -56,10 +56,31 @@
 	let sortField: keyof PortfolioData | null = null;
 	let sortDirection: SortDirection = "asc";
 
-	const columns: Array<{ label: string; key: keyof PortfolioData }> = [
+	// Column-level renderer override. PortfolioData.portfolioAsOf comes
+	// from ZonedDateTime.toString() ("YYYY/MM/DD HH:MM:SS" UTC) — too
+	// noisy for an index column. Format to plain UTC YYYY-MM-DD; em-dash
+	// for missing/malformed (the per-row guard from #221's
+	// safe()-wrapped page-server may emit '' here when getAsOf()
+	// throws).
+	function formatAsOf(raw: string | undefined): string {
+		if (!raw) return '—';
+		// Accept either "YYYY/MM/DD ..." (the wrapper's output) or
+		// "YYYY-MM-DD" (test fixtures already in target shape) or any
+		// other ISO-ish prefix. Anything we don't recognize → em-dash.
+		const m = raw.match(/^(\d{4})[-/](\d{2})[-/](\d{2})/);
+		return m ? `${m[1]}-${m[2]}-${m[3]}` : '—';
+	}
+
+	type Column = {
+		label: string;
+		key: keyof PortfolioData;
+		format?: (raw: string) => string;
+	};
+
+	const columns: Array<Column> = [
 		{ label: "Portfolio", key: "portfolioName" },
 		{ label: "ID", key: "portfolioId" },
-		{ label: "Created (AsOf)", key: "portfolioAsOf" },
+		{ label: "As Of", key: "portfolioAsOf", format: formatAsOf },
 	];
 
 	$: sortedRows = sortData(rows, sortField, sortDirection);
@@ -119,7 +140,7 @@
 						{#each columns as column}
 							<td class="table-cell px-4 py-2">
 								<a href={getPositionsUrl(row.portfolioId)} class="row-link">
-									{row[column.key]}
+									{column.format ? column.format(row[column.key] ?? '') : row[column.key]}
 								</a>
 							</td>
 						{/each}

--- a/src/routes/(authenticated)/data/portfolios/+page.server.ts
+++ b/src/routes/(authenticated)/data/portfolios/+page.server.ts
@@ -3,34 +3,51 @@ import {PortfolioService} from "@fintekkers/ledger-models/node/wrappers/services
 import * as dt from "@fintekkers/ledger-models/node/wrappers/models/utils/datetime";
 import {PositionFilter} from "@fintekkers/ledger-models/node/wrappers/models/position/positionfilter";
 import type Portfolio from "@fintekkers/ledger-models/node/wrappers/models/portfolio/portfolio";
-import pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/field_pb.js';
 import { deleteEntity } from '$lib/entity-delete';
 import { FetchTransactionByPortfolio } from '$lib/transactions';
-
-const { FieldProto } = pkg;
 
 /** @type {import('../../../../../.svelte-kit/types/src/routes').PageServerLoad} */
 export async function load({locals, request}) {
   const now = dt.ZonedDateTime.now();
   const portfolioService = new PortfolioService(locals.user?.apiKey);
 
+  // Empty filter = all portfolios. The SOMA-only PORTFOLIO_NAME
+  // filter that lived here previously was a single-portfolio-seed
+  // expedient that became second-brain#221 once the seed grew —
+  // truncated the page to exactly the one portfolio name it
+  // hardcoded. Page is the portfolios index; it should list every
+  // portfolio the API returns.
   const filter: PositionFilter = new PositionFilter();
-  filter.addEqualsFilter(FieldProto.PORTFOLIO_NAME, "Federal Reserve SOMA Holdings");
 
   const portfolioData = await portfolioService
     .searchPortfolio(now.toProto(), filter)
     .then((portfolios: Portfolio[]) => {
       console.log("Portfolios found: " + portfolios.length);
-      return portfolios.map(portfolio => {
+      // Per-row try/catch — a single malformed portfolio (e.g. a
+      // missing/invalid asOf timestamp on legacy or partial data)
+      // shouldn't tank the whole list. Same defensive pattern as
+      // security.ts:elementsToReturn. Pre-#221 the hardcoded
+      // PORTFOLIO_NAME filter incidentally hid these crashes by
+      // narrowing to one well-formed row.
+      const safe = <T>(fn: () => T, fallback: T): T => {
+        try { return fn(); } catch { return fallback; }
+      };
+      const rows: Array<{ portfolioName: string; portfolioAsOf: string; portfolioId: string; uuidHex: string }> = [];
+      for (const portfolio of portfolios) {
+        try {
           const uuidProto = portfolio.proto?.getUuid?.();
           const uuidHex = uuidProto ? Buffer.from(uuidProto.serializeBinary()).toString('hex') : '';
-          return {
-              portfolioName: portfolio.getPortfolioName(),
-              portfolioAsOf: portfolio.getAsOf().toString(),
-              portfolioId: portfolio.getID().toString(),
-              uuidHex,
-          };
-      });
+          rows.push({
+            portfolioName: safe(() => portfolio.getPortfolioName(), ''),
+            portfolioAsOf: safe(() => portfolio.getAsOf().toString(), ''),
+            portfolioId: safe(() => portfolio.getID().toString(), ''),
+            uuidHex,
+          });
+        } catch (rowErr: any) {
+          console.warn('Skipping portfolio row due to wrapper error:', rowErr?.message ?? rowErr);
+        }
+      }
+      return rows;
     })
     .catch((err: Error) => {
       console.error("Portfolio fetch error:", err.message);

--- a/src/tests/PortfolioGrid.test.ts
+++ b/src/tests/PortfolioGrid.test.ts
@@ -37,12 +37,15 @@ describe('PortfolioGrid', () => {
 		}
 	});
 
-	test('renders column headers for Portfolio, ID, and Created (AsOf)', () => {
+	test('renders column headers for Portfolio, ID, and As Of', () => {
 		const headers = screen.getAllByRole('button');
 		const headerTexts = headers.map((h) => h.textContent?.trim());
 		expect(headerTexts).toContain('Portfolio');
 		expect(headerTexts).toContain('ID');
-		expect(headerTexts).toContain('Created (AsOf)');
+		// Renamed from "Created (AsOf)" — the column now shows just the
+		// UTC date (formatted via PortfolioGrid.formatAsOf), not a
+		// timestamp; the legacy label was misleading.
+		expect(headerTexts).toContain('As Of');
 	});
 
 	test('each row contains links with the correct positions URL', () => {
@@ -156,5 +159,41 @@ describe('PortfolioGrid with empty rows', () => {
 		const rows = screen.getAllByRole('row');
 		// Only the header row
 		expect(rows.length).toBe(1);
+	});
+});
+
+describe('PortfolioGrid As Of formatting', () => {
+	test('renders ZonedDateTime "YYYY/MM/DD HH:MM:SS" as plain UTC YYYY-MM-DD', () => {
+		render(PortfolioGrid, {
+			props: {
+				rows: [{
+					portfolioName: 'Test',
+					portfolioId: 'p-1',
+					// Shape produced by the wrappers' ZonedDateTime.toString()
+					portfolioAsOf: '2026/05/08 12:34:56',
+				}],
+			},
+		});
+		expect(screen.getByText('2026-05-08')).toBeInTheDocument();
+		// Time-of-day component is dropped.
+		expect(screen.queryByText(/12:34:56/)).toBeNull();
+	});
+
+	test('renders em-dash for empty/missing asOf (per-row guard fallback)', () => {
+		render(PortfolioGrid, {
+			props: {
+				rows: [{ portfolioName: 'Test', portfolioId: 'p-2', portfolioAsOf: '' }],
+			},
+		});
+		expect(screen.getByText('—')).toBeInTheDocument();
+	});
+
+	test('renders em-dash for malformed asOf', () => {
+		render(PortfolioGrid, {
+			props: {
+				rows: [{ portfolioName: 'Test', portfolioId: 'p-3', portfolioAsOf: 'not-a-date' }],
+			},
+		});
+		expect(screen.getByText('—')).toBeInTheDocument();
 	});
 });

--- a/tests/e2e/portfolios-show-all.spec.ts
+++ b/tests/e2e/portfolios-show-all.spec.ts
@@ -91,5 +91,16 @@ test.describe('/data/portfolios index (#221)', () => {
     await expect(somaRow, 'SOMA row present').toHaveCount(1, { timeout: 10_000 });
     await expect(probeRow, 'fresh probe portfolio renders post-#221 fix')
       .toHaveCount(1, { timeout: 10_000 });
+
+    // As Of column renders post-#221 amend (column header + a YYYY-MM-DD
+    // date for our freshly-created probe portfolio). The probe was
+    // just created so its asOf is today (or yesterday-UTC if the test
+    // runs near midnight); assert the YYYY-MM-DD shape rather than a
+    // specific date.
+    await expect(page.getByRole('button', { name: /^As Of/ }), 'As Of header renders')
+      .toBeVisible();
+    const probeAsOfCell = probeRow.locator('td').last();
+    await expect(probeAsOfCell, 'fresh portfolio renders a YYYY-MM-DD asOf cell')
+      .toContainText(/^\d{4}-\d{2}-\d{2}$/);
   });
 });

--- a/tests/e2e/portfolios-show-all.spec.ts
+++ b/tests/e2e/portfolios-show-all.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression for second-brain#221 — /data/portfolios used to hardcode
+ * a `PORTFOLIO_NAME == "Federal Reserve SOMA Holdings"` filter on the
+ * search call, truncating the index to exactly that one row even
+ * when the backend held multiple portfolios. The fix removes the
+ * filter; this test asserts the un-filtered list shows up.
+ *
+ * To make the assertion deterministic regardless of seed state, the
+ * test creates a fresh portfolio with a unique name via the
+ * ledger-service Portfolio/CreateOrUpdate RPC (mirrors the helper in
+ * src/tests/qa-s8-price-portfolio.test.ts), then asserts BOTH that
+ * fresh portfolio AND the SOMA seed appear on the page. Pre-#221 fix
+ * the SOMA filter would have hidden the fresh one.
+ */
+import { test, expect } from '@playwright/test';
+import grpc from '@grpc/grpc-js';
+
+const SOMA_NAME = 'Federal Reserve SOMA Holdings';
+const LEDGER_URL = 'localhost:8082';
+
+async function createPortfolio(name: string): Promise<void> {
+  // ESM dynamic-import-of-CJS quirk: the proto modules export named
+  // bindings the linker doesn't always destructure, so go through
+  // `default` / `module` shapes defensively. (qa-s8-price-portfolio
+  // uses the same pattern under vitest where the destructure works
+  // straight; under playwright runner the wrapper namespace differs.)
+  const grpcPkg = (await import(
+    '@fintekkers/ledger-models/node/fintekkers/services/portfolio-service/portfolio_service_grpc_pb.js'
+  )) as any;
+  const PortfolioClient = grpcPkg.PortfolioClient ?? grpcPkg.default?.PortfolioClient;
+
+  const reqPkg = (await import(
+    '@fintekkers/ledger-models/node/fintekkers/requests/portfolio/create_portfolio_request_pb.js'
+  )) as any;
+  const CreatePortfolioRequestProto =
+    reqPkg.CreatePortfolioRequestProto ?? reqPkg.default?.CreatePortfolioRequestProto;
+
+  const protoPkg = (await import(
+    '@fintekkers/ledger-models/node/fintekkers/models/portfolio/portfolio_pb.js'
+  )) as any;
+  const PortfolioProto = protoPkg.PortfolioProto ?? protoPkg.default?.PortfolioProto;
+
+  const uuidPkg = (await import(
+    '@fintekkers/ledger-models/node/wrappers/models/utils/uuid.js'
+  )) as any;
+  const UUID = uuidPkg.UUID ?? uuidPkg.default?.UUID;
+
+  const dtPkg = (await import(
+    '@fintekkers/ledger-models/node/wrappers/models/utils/datetime.js'
+  )) as any;
+  const ZonedDateTime = dtPkg.ZonedDateTime ?? dtPkg.default?.ZonedDateTime;
+
+  const portfolio = new PortfolioProto();
+  portfolio.setObjectClass('Portfolio');
+  portfolio.setVersion('0.0.1');
+  portfolio.setAsOf(ZonedDateTime.now().toProto());
+  portfolio.setPortfolioName(name);
+  portfolio.setUuid(UUID.random().toUUIDProto());
+
+  const req = new CreatePortfolioRequestProto();
+  req.setObjectClass('PortfolioRequest');
+  req.setVersion('0.0.1');
+  req.setCreatePortfolioInput(portfolio);
+
+  const client = new PortfolioClient(LEDGER_URL, grpc.credentials.createInsecure());
+
+  await new Promise<void>((resolve, reject) => {
+    client.createOrUpdate(req, (err: any) => {
+      if (err) reject(new Error(`${err.code}: ${err.details ?? err.message}`));
+      else resolve();
+    });
+  });
+}
+
+test.describe('/data/portfolios index (#221)', () => {
+  test('lists every portfolio (the SOMA-only filter is gone)', async ({ page }) => {
+    // Seed a fresh portfolio so the assertion is deterministic
+    // regardless of what's already on the backend.
+    const probeName = `qa-221-probe-${Date.now().toString(36)}`;
+    await createPortfolio(probeName);
+
+    await page.goto('/data/portfolios');
+    await expect(page.getByRole('heading', { name: 'Portfolios' })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Both rows must render. Pre-fix, the hardcoded SOMA filter would
+    // have hidden the probe portfolio entirely.
+    const somaRow = page.locator('table tbody tr', { hasText: SOMA_NAME });
+    const probeRow = page.locator('table tbody tr', { hasText: probeName });
+    await expect(somaRow, 'SOMA row present').toHaveCount(1, { timeout: 10_000 });
+    await expect(probeRow, 'fresh probe portfolio renders post-#221 fix')
+      .toHaveCount(1, { timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
Closes [second-brain#221](https://github.com/FinTekkers/second-brain/issues/221).

## Investigation

Traced from `PortfolioGrid.svelte` → `src/routes/(authenticated)/data/portfolios/+page.server.ts` → `PortfolioService.searchPortfolio`. **UI bug**, not backend: the page-server hard-coded a `PORTFOLIO_NAME == "Federal Reserve SOMA Holdings"` filter on the search call (line 18 pre-fix). Single-portfolio-seed expedient that became #221 once the seed grew.

## Two fixes

1. **Drop the SOMA-only filter** (the proximate cause). The page is the portfolios index — it should list every portfolio the API returns, not the one whose name we hardcoded. Empty `PositionFilter` → all portfolios.
2. **Per-row defensive guard** (the necessary follow-up). With the filter dropped, a single malformed portfolio (e.g. missing/invalid `asOf`) propagated through `.map()` → `.toString()` → `"Invalid time value"`, which the existing `.catch` surfaced as a whole-page error row. Same shape as `security.ts:elementsToReturn`'s legacy-data guard. Per-row try/catch + `safe()` helper so one bad row doesn't tank the whole list.

Both fixes ship together because dropping the filter without the guard would replace the truncation bug with a worse UX (whole-page error from a single bad row).

## Test

`tests/e2e/portfolios-show-all.spec.ts`:
- Creates a portfolio with a unique name via the ledger-service `Portfolio/CreateOrUpdate` RPC (mirrors the helper in `src/tests/qa-s8-price-portfolio.test.ts`).
- Navigates to `/data/portfolios`.
- Asserts **both** the SOMA seed AND the freshly-created portfolio render.

Pre-fix, the SOMA-only filter would have hidden the fresh row entirely — that's what the regression test catches.

## Test plan

- [x] `npx svelte-check` — **83/205** unchanged from `main` baseline.
- [x] `npx vitest run` — 40/40 files, **557/557 passing**.
- [x] `npx playwright test tests/e2e/portfolios-show-all.spec.ts` — 1/1 pass.
- [x] `npx playwright test` (full) — 33/34 pass.

## Pre-existing failure flagged (not introduced by this PR)

`tests/e2e/prices.spec.ts:60` (`autocomplete suggests TSLA and selecting it navigates to the TSLA chart`) fails on this branch AND on `main`. Verified by checking out `main` and running the test — same failure mode (`expect(locator).toContainText('TSLA')` on `h3.chart-title`). Surfaced as a separate ticket; not in this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)