### PR TITLE
fix(tests): tests/e2e/prices.spec.ts:60 TSLA autocomplete (#239)

### DIFF
--- a/tests/e2e/prices.spec.ts
+++ b/tests/e2e/prices.spec.ts
@@ -57,7 +57,19 @@ test.describe('/data/prices', () => {
     await expect(input).toHaveAttribute('placeholder', /912828ZT0/);
   });
 
-  test('autocomplete suggests TSLA and selecting it navigates to the TSLA chart', async ({ page }) => {
+  test('autocomplete suggests TSLA and selecting it navigates to /data/prices?id=TSLA (#239)', async ({ page }) => {
+    // What this test exercises: the autocomplete dropdown surfaces a
+    // matching ticker and clicking the suggestion navigates to that
+    // ticker's prices URL. Chart rendering is covered by the AAPL
+    // default-landing test above; deliberately NOT re-asserted here
+    // because price-history availability is a seed-data concern, not
+    // something the autocomplete-and-navigate flow controls.
+    //
+    // Pre-#239 this test asserted h3.chart-title + svg.main-svg + 100+
+    // table rows on TSLA. The seed (correctly) has no TSLA prices, so
+    // the page shows the empty-state ("No price history found for
+    // TSLA") and the chart selectors don't match. Test drift, not a
+    // product bug — the user-facing flow works as intended.
     await page.goto('/data/prices');
     await page.waitForLoadState('networkidle');
 
@@ -70,17 +82,21 @@ test.describe('/data/prices', () => {
     await input.fill('TSL');
 
     const suggestion = page.locator('ul.suggestions li').filter({ hasText: 'TSLA' }).first();
-    await expect(suggestion).toBeVisible({ timeout: 5_000 });
+    await expect(suggestion, 'autocomplete surfaces TSLA').toBeVisible({ timeout: 10_000 });
     await suggestion.click();
 
     // The select navigates via window.location.href; assert the new URL.
-    await page.waitForURL(/\/data\/prices\?type=ticker&id=TSLA/);
+    await page.waitForURL(/\/data\/prices\?type=ticker&id=TSLA/, { timeout: 10_000 });
 
-    // Chart rerenders with TSLA.
-    await expect(page.locator('h3.chart-title')).toContainText('TSLA');
-    await expect(page.locator('.price-chart svg.main-svg').first()).toBeVisible({ timeout: 15_000 });
-
-    // Table is non-empty.
-    expect(await page.locator('table tbody tr').count()).toBeGreaterThan(100);
+    // After navigation: input reflects the picked ticker, page renders
+    // TSLA in the security description (whether or not a price chart
+    // accompanies it). These assertions prove the autocomplete →
+    // navigation → SSR-hydration round-trip without coupling to
+    // price-data availability for TSLA.
+    await expect(input, 'input mirrors the picked ticker').toHaveValue('TSLA');
+    await expect(
+      page.locator('p.security-desc'),
+      'security description renders TSLA',
+    ).toContainText('TSLA');
   });
 });


### PR DESCRIPTION
Closes [second-brain#239](https://github.com/FinTekkers/second-brain/issues/239). Pre-existing flake on `main` flagged in PR #150's verification.

## Diagnosis

**Test drift, not a product bug.** Manually verified the user-facing flow in the browser: type `TSL` → autocomplete suggests TSLA → click → page navigates to `/data/prices?type=ticker&id=TSLA` → input value = `TSLA`, security description = `"TSLA — dummy issuer"`, body shows `"No price history found for TSLA"`. That's the correct UX for a ticker with no price data in the seed.

The spec's failure mode was the chart-and-table assertions:
```ts
await expect(page.locator('h3.chart-title')).toContainText('TSLA');     // ❌ no chart-title in DOM
await expect(page.locator('.price-chart svg.main-svg').first()).toBeVisible();
expect(await page.locator('table tbody tr').count()).toBeGreaterThan(100);
```

Looking at `+page.svelte:225`:
```svelte
{#if prices.length > 0 && selectedIdentifier}
  <div class="chart-box">
    <h3 class="chart-title">Price Chart — {selectedIdentifier}</h3>
    ...
{:else if selectedIdentifier && !priceError}
  <p class="empty-msg">No price history found for {selectedIdentifier}.</p>
```

`h3.chart-title` only renders when `prices.length > 0`. TSLA has no prices, so the empty-state branch fires.

## Fix

Rewrite the post-click assertions to test what autocomplete-and-navigate actually proves:

```ts
await page.waitForURL(/\/data\/prices\?type=ticker&id=TSLA/);
await expect(input).toHaveValue('TSLA');
await expect(page.locator('p.security-desc')).toContainText('TSLA');
```

URL, input value, security-desc text — all independent of price-data availability. Chart rendering on a known-priced ticker is already covered by the **AAPL default-landing test** in the same file (line 16), so dropping the chart assertions here doesn't lose coverage.

Also bumped the suggestion-visible `toBeVisible` timeout from 5s → 10s, matching PR #147's hardening pattern for the other autocomplete tests.

## Test plan

- [x] `npx playwright test tests/e2e/prices.spec.ts` — **4/4 pass**.
- [x] `npx playwright test` (full) — **34/34 pass on first run** (was 33/34 with this exact failure as the holdout).
- [x] `npx svelte-check` — 83/205, unchanged from `main` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)