### PR TITLE
chore: drop ?cusip= and snake_case operator URL deprecation shims

### DIFF
--- a/src/components/widgets/PositionSelect.svelte
+++ b/src/components/widgets/PositionSelect.svelte
@@ -109,8 +109,6 @@
         measures: selectedMeasures.join(","),
         identifier: trimmedIdentifier || undefined,
         identifierType: trimmedIdentifier ? identifierType : undefined,
-        // No legacy ?cusip= override needed: a stale ?cusip= bookmark
-        // naturally disappears on re-submit (no inheritKeys carries it).
         tradeDate: tradeDateOverride,
         tradeDateOperator: tradeDateOperatorOverride,
         assetClass: assetClassInput.trim() || undefined,
@@ -136,7 +134,6 @@
       const selectedPositionViewFromUrl = urlParams.get("positionView");
       const identifierFromUrl = urlParams.get("identifier");
       const identifierTypeFromUrl = urlParams.get("identifierType");
-      const legacyCusipFromUrl = urlParams.get("cusip");
       const tradeDateFromUrl = urlParams.get("tradeDate");
       const tradeDateOperatorFromUrl = urlParams.get("tradeDateOperator");
       const assetClassFromUrl = urlParams.get("assetClass");
@@ -162,10 +159,10 @@
           .map(formatName);
       }
 
-      // Identifier load order: canonical (?identifier=…&identifierType=…)
-      // wins; fall back to the legacy ?cusip=… bookmark and pin the type
-      // to CUSIP. The page-server emits a deprecation warning when it
-      // sees the legacy shape, so users still get a signal.
+      // Identifier load: canonical (?identifier=…&identifierType=…)
+      // shape only. The pre-#227 ?cusip=<value> shim was dropped after
+      // its one-release window; see /data/positions/+page.server.ts
+      // for the rationale.
       if (identifierFromUrl) {
         identifierInput = identifierFromUrl;
         if (
@@ -174,9 +171,6 @@
         ) {
           identifierType = identifierTypeFromUrl as IdentifierTypeName;
         }
-      } else if (legacyCusipFromUrl) {
-        identifierInput = legacyCusipFromUrl;
-        identifierType = "CUSIP";
       }
 
       if (tradeDateFromUrl) {

--- a/src/routes/(authenticated)/data/positions/+page.server.ts
+++ b/src/routes/(authenticated)/data/positions/+page.server.ts
@@ -72,24 +72,18 @@ export async function load({ locals, request }) {
   const measures = searchParams.get('measures');
   // Identifier filter — second-brain#227. Canonical shape:
   //   ?identifier=<value>&identifierType=<CUSIP|ISIN|EXCH_TICKER|…>
-  // Backward-compat shim: ?cusip=<value> is treated as
-  // ?identifier=<value>&identifierType=CUSIP for one release. The
-  // deprecation warning logs once per request hit; remove the shim in a
-  // future release once stale bookmarks are unlikely.
-  let identifier = searchParams.get('identifier');
+  // The pre-#227 ?cusip=<value> shim shipped in PR #134 with an
+  // explicit one-release plan and was dropped in this commit (the
+  // window has long since elapsed: shim shipped on ledger-models
+  // v0.1.133, current is v0.1.137). A stale bookmark with ?cusip=
+  // now no-ops at this layer — the page renders the default-landing
+  // state without crashing.
+  const identifier = searchParams.get('identifier');
   const rawIdentifierType = searchParams.get('identifierType');
-  let identifierType: IdentifierTypeName | undefined =
+  const identifierType: IdentifierTypeName | undefined =
     rawIdentifierType && (IDENTIFIER_TYPE_NAMES as readonly string[]).includes(rawIdentifierType)
       ? (rawIdentifierType as IdentifierTypeName)
       : undefined;
-  const legacyCusip = searchParams.get('cusip');
-  if (!identifier && legacyCusip) {
-    console.warn(
-      "[deprecation] /data/positions ?cusip=… is deprecated; use ?identifier=…&identifierType=CUSIP. (#227 backward-compat shim)",
-    );
-    identifier = legacyCusip;
-    identifierType = identifierType ?? 'CUSIP';
-  }
   const tradeDate = searchParams.get('tradeDate');
   // Operator passes through untransformed — PositionFilterOperator's
   // fromName (in $lib/positions) is the only validator (#229 review).

--- a/tests/e2e/positions-identifier-filter.spec.ts
+++ b/tests/e2e/positions-identifier-filter.spec.ts
@@ -2,23 +2,27 @@
  * Regression for second-brain#227 (PositionSelect → IdentifierFilter)
  * AND second-brain#226 phase 3 PR-A (PositionSelect → DateFilter).
  *
- * Five cases:
+ * Four cases:
  *   1. CUSIP — ?identifier+identifierType=CUSIP loads into the form,
  *      Fetch round-trips the URL with portfolioId carried via inheritKeys
  *      (#220-style guard).
  *   2. EXCH_TICKER — same flow with identifierType=EXCH_TICKER.
- *   3. Legacy ?cusip=… bookmark loads into the IdentifierFilter input
- *      and re-emits as canonical (?identifier+identifierType=CUSIP) on
- *      next Fetch, with no ?cusip= residue.
- *   4. tradeDate + tradeDateOperator — both URL params load into
+ *   3. tradeDate + tradeDateOperator — both URL params load into
  *      DateFilter, Fetch round-trips both with portfolioId preserved.
- *   5. tradeDate alone (no operator) — the date populates the DateFilter
+ *   4. tradeDate alone (no operator) — the date populates the DateFilter
  *      input, the operator select stays empty (and disabled). Fetch
  *      doesn't crash; the half-applied filter guard in
  *      PositionSelect.fetchPositions drops both params on re-emit (a
  *      type-without-value or value-without-type filter is meaningless
  *      to the page-server). Documented behavior; not a UX regression
  *      for this PR.
+ *
+ * Pre-existing case removed: the "legacy ?cusip= bookmark migrates"
+ * test covered the PR #134 deprecation shim that's been removed
+ * post-#239 — see the chore: drop-deprecation-shims commit. The
+ * "no legacy ?cusip= re-emitted" negative assertions on the canonical
+ * cases are kept as harmless regression guards (still meaningful: the
+ * form must not accidentally emit ?cusip= on its own).
  *
  * Why URL-load instead of dropdown-then-fill: testing via the dropdown
  * triggers IdentifierFilter's clearOnTypeChange handler, whose bind
@@ -91,29 +95,6 @@ test.describe('/data/positions IdentifierFilter (#227)', () => {
     expect(params.get('identifierType'), 'identifierType pinned to EXCH_TICKER').toBe('EXCH_TICKER');
     expect(params.get('cusip'), 'no legacy ?cusip= re-emitted').toBeNull();
     expect(params.get('portfolioId'), '#220 guard: portfolioId preserved').toBe(portfolioId);
-  });
-
-  test('legacy ?cusip= bookmark migrates to canonical shape on Fetch', async ({ page }) => {
-    const portfolioId = await resolvePortfolioId(page);
-
-    await page.goto(
-      `/data/positions?portfolioId=${portfolioId}` +
-      `&cusip=${PROBE_CUSIP}` +
-      `&fields=SECURITY_DESCRIPTION&measures=DIRECTED_QUANTITY`,
-    );
-    const idInput = page.locator('#position-identifier-input');
-    await expect(idInput).toBeVisible({ timeout: 10_000 });
-    await expect(idInput, 'legacy cusip value populates IdentifierFilter input').toHaveValue(PROBE_CUSIP);
-    await expect(page.getByLabel('Identifier type'), 'legacy entry pins type=CUSIP').toHaveValue('CUSIP');
-
-    await page.getByRole('button', { name: 'Fetch' }).click();
-    await page.waitForURL(/\/data\/positions\?.*identifier=/, { timeout: 10_000 });
-
-    const params = new URL(page.url()).searchParams;
-    expect(params.get('identifier')).toBe(PROBE_CUSIP);
-    expect(params.get('identifierType'), 'legacy entry re-emits with type=CUSIP').toBe('CUSIP');
-    expect(params.get('cusip'), 'legacy ?cusip= must be gone after re-emission').toBeNull();
-    expect(params.get('portfolioId')).toBe(portfolioId);
   });
 
   test('tradeDate + tradeDateOperator round-trip through Fetch with portfolio scope', async ({ page }) => {


### PR DESCRIPTION
PM dispatch called for removing two shims that have shipped past their stated one-release window. Investigation found one already gone, one still live.

## ?cusip= shim — REMOVED here

Added in [PR #134](https://github.com/FinTekkers/ui-service/pull/134) for `/data/positions`, replacing it with `?identifier=…&identifierType=CUSIP`. Shipped on `ledger-models v0.1.133`; we're at **`v0.1.137`** — multiple releases past the one-release window stated in the original PR.

Removed:
- `src/routes/(authenticated)/data/positions/+page.server.ts` — `legacyCusip` read + `console.warn` fallback.
- `src/components/widgets/PositionSelect.svelte` — `loadSelectedValues()`'s `legacyCusipFromUrl` branch + the inline `?cusip=` override comment.
- `tests/e2e/positions-identifier-filter.spec.ts` — the "legacy ?cusip= bookmark migrates to canonical shape" regression case (no shim to assert against). The two "no legacy ?cusip= re-emitted" **negative** assertions on the canonical CUSIP / EXCH_TICKER paths are **kept** as harmless guards (still meaningful: the form must not accidentally emit `?cusip=` on its own).

User-facing impact: any stale bookmark `?cusip=ABC` now lands on `/data/positions`'s default-landing state without a crash — same outcome as any typo'd query param.

## ?tradeDateOperator snake_case shim — already gone

Added in [PR #144](https://github.com/FinTekkers/ui-service/pull/144), shipped on `v0.1.135`. **Verified by grep**: `src/lib/filters/dateOperator.ts` was deleted entirely during PR #144's round-2 review amends, along with `normalizeDateOperator`. Zero `greater_than` / `lesser_than` / `normalizeDateOperator` references remain in URL-handling code paths.

```
$ grep -rn "normalizeDateOperator\|greater_than\|lesser_than" --include="*.ts" --include="*.svelte" src/ tests/ \
    | grep -v ".svelte-kit" | grep -v node_modules
(no output)
```

So this PR is single-shim cleanup despite the dispatch's two-shim framing. Surfaced cleanly in the commit message rather than merging speculative removals.

## Test plan

- [x] `npx svelte-check` — **83/205**, unchanged from `main` baseline.
- [x] `npx vitest run` — 40/40 files, **560/560 passing**.
- [x] `npx playwright test` — **33/33 passing** (was 34 with the legacy migration test in this file; deleted, net −1 expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)