### PR TITLE
consume Measure wrapper from ledger-models 0.1.138 (Phase 3 of #226 follow-up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@auth/core": "^0.27.0",
 				"@auth/sveltekit": "^0.13.0",
-				"@fintekkers/ledger-models": "^0.1.135",
+				"@fintekkers/ledger-models": "^0.1.138",
 				"@iconify-json/mdi": "^1.2.3",
 				"@iconify-json/ph": "^1.2.2",
 				"@lucia-auth/adapter-drizzle": "^1.0.7",
@@ -2528,9 +2528,9 @@
 			}
 		},
 		"node_modules/@fintekkers/ledger-models": {
-			"version": "0.1.135",
-			"resolved": "https://registry.npmjs.org/@fintekkers/ledger-models/-/ledger-models-0.1.135.tgz",
-			"integrity": "sha512-/RYsatQ12yeGnHTbIG1qdnIey3ve06SoImbttO4h3nND/yqpZyso7UbLZ6OoHNNe5wN/+FQHdBY6lZftY+tFOA==",
+			"version": "0.1.138",
+			"resolved": "https://registry.npmjs.org/@fintekkers/ledger-models/-/ledger-models-0.1.138.tgz",
+			"integrity": "sha512-oyKTfj5tQYz4hdDy9v0p1X4bPl1cWjcYs6rJ3EW2fI2hoDxqM6agtxi5tU12bYqoH2mQ7xJtB1K//9L3yh1DMw==",
 			"license": "ISC",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.8.18",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"@auth/core": "^0.27.0",
 		"@auth/sveltekit": "^0.13.0",
-		"@fintekkers/ledger-models": "^0.1.135",
+		"@fintekkers/ledger-models": "^0.1.138",
 		"@iconify-json/mdi": "^1.2.3",
 		"@iconify-json/ph": "^1.2.2",
 		"@lucia-auth/adapter-drizzle": "^1.0.7",

--- a/src/components/filters/MeasureMultiselectFilter.svelte
+++ b/src/components/filters/MeasureMultiselectFilter.svelte
@@ -18,14 +18,22 @@
    * is already proto names, so a malformed URL just produces an
    * unselected option in the dropdown.
    */
-  import measure_pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/measure_pb.js';
-  const { MeasureProto } = measure_pkg;
+  // Measure wrapper from ledger-models 0.1.138+ (PR #194). Same
+  // consumer pattern as IDENTIFIER_TYPE_NAMES (#188), SECURITY_TYPE_NAMES
+  // / ASSET_CLASS_NAMES (#189), PositionFilterOperator (#190). The
+  // wrapper's getAllTypeNames() is the source-of-truth for "every
+  // known measure name (sentinel UNKNOWN_MEASURE excluded)" — adding
+  // a new proto entry upstream auto-propagates to this dropdown.
+  import { Measure } from '@fintekkers/ledger-models/node/wrappers/models/position/measure';
 
   // Valuation-only measures are excluded by default — they require a
   // RunValuation call rather than the Position search the basic
   // /data/positions page hits, so showing them in the multiselect
   // would surface a silent no-op. Consumers that want them (a future
   // valuations page) can pass a different supportedMeasures list.
+  // This is a UI policy choice on which measures belong on which
+  // page, not a claim about the vocabulary itself — the vocabulary
+  // lives upstream in ledger-models.
   const VALUATION_ONLY_MEASURES = new Set([
     'PRESENT_VALUE_CASHFLOWS',
     'PRESENT_VALUE',
@@ -36,12 +44,11 @@
   ]);
 
   /**
-   * The default proto-name allowlist: every MeasureProto enum entry
-   * minus the valuation-only set. Drives the dropdown options when
-   * the consumer doesn't pass a custom `supportedMeasures` prop.
+   * The default proto-name allowlist: every Measure entry from the
+   * wrapper minus the valuation-only set.
    */
-  export const DEFAULT_MEASURE_NAMES: readonly string[] = Object.keys(MeasureProto)
-    .filter((k) => typeof (MeasureProto as Record<string, unknown>)[k] === 'number')
+  export const DEFAULT_MEASURE_NAMES: readonly string[] = Measure
+    .getAllTypeNames()
     .filter((k) => !VALUATION_ONLY_MEASURES.has(k));
 
   function titleCase(name: string): string {

--- a/src/components/filters/MeasureMultiselectFilter.svelte
+++ b/src/components/filters/MeasureMultiselectFilter.svelte
@@ -25,31 +25,46 @@
   // known measure name (sentinel UNKNOWN_MEASURE excluded)" — adding
   // a new proto entry upstream auto-propagates to this dropdown.
   import { Measure } from '@fintekkers/ledger-models/node/wrappers/models/position/measure';
+  import measure_pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/measure_pb.js';
+  // The runtime destructure gives us the value namespace
+  // (MeasureProto.PRESENT_VALUE etc.); the type-only alias lets us
+  // annotate `Set<MeasureProtoType>` without the value-vs-type
+  // collision. Same pattern as FieldProto / FieldProtoType in
+  // positions.ts and elsewhere.
+  import type { MeasureProto as MeasureProtoType } from '@fintekkers/ledger-models/node/fintekkers/models/position/measure_pb';
+  const { MeasureProto } = measure_pkg;
 
   // Valuation-only measures are excluded by default — they require a
   // RunValuation call rather than the Position search the basic
   // /data/positions page hits, so showing them in the multiselect
   // would surface a silent no-op. Consumers that want them (a future
   // valuations page) can pass a different supportedMeasures list.
-  // This is a UI policy choice on which measures belong on which
-  // page, not a claim about the vocabulary itself — the vocabulary
-  // lives upstream in ledger-models.
-  const VALUATION_ONLY_MEASURES = new Set([
-    'PRESENT_VALUE_CASHFLOWS',
-    'PRESENT_VALUE',
-    'REAL_YIELD',
-    'INFLATION_ADJUSTED_PRINCIPAL',
-    'DISCOUNT_MARGIN',
-    'SPREAD_DURATION',
+  //
+  // Set keyed by MeasureProto enum *values* (not name strings) so
+  // TypeScript catches drift if any of these proto entries gets
+  // renamed/removed upstream — the static reference fails to compile
+  // rather than silently no-op'ing at runtime. Per #154 review
+  // feedback: prefer strongly-typed enum members over string
+  // literals when the comparison target is a proto identity.
+  const VALUATION_ONLY_MEASURES = new Set<MeasureProtoType>([
+    MeasureProto.PRESENT_VALUE_CASHFLOWS,
+    MeasureProto.PRESENT_VALUE,
+    MeasureProto.REAL_YIELD,
+    MeasureProto.INFLATION_ADJUSTED_PRINCIPAL,
+    MeasureProto.DISCOUNT_MARGIN,
+    MeasureProto.SPREAD_DURATION,
   ]);
 
   /**
    * The default proto-name allowlist: every Measure entry from the
-   * wrapper minus the valuation-only set.
+   * wrapper minus the valuation-only set. The set lookup goes via
+   * Measure.fromName so the (string-name-from-getAllTypeNames) →
+   * (numeric-enum-value-in-Set) translation always uses the wrapper
+   * — keeping ledger-models as the single point of name resolution.
    */
   export const DEFAULT_MEASURE_NAMES: readonly string[] = Measure
     .getAllTypeNames()
-    .filter((k) => !VALUATION_ONLY_MEASURES.has(k));
+    .filter((name) => !VALUATION_ONLY_MEASURES.has(Measure.fromName(name)));
 
   function titleCase(name: string): string {
     return name

--- a/src/components/filters/MeasureMultiselectFilter.test.ts
+++ b/src/components/filters/MeasureMultiselectFilter.test.ts
@@ -1,5 +1,6 @@
 import { render, fireEvent } from '@testing-library/svelte';
 import { describe, expect, test } from 'vitest';
+import { Measure } from '@fintekkers/ledger-models/node/wrappers/models/position/measure';
 import MeasureMultiselectFilter, {
   DEFAULT_MEASURE_NAMES,
   DEFAULT_MEASURE_LABELS,
@@ -33,6 +34,19 @@ describe('MeasureMultiselectFilter', () => {
       'DISCOUNT_MARGIN',
       'SPREAD_DURATION',
     ]));
+  });
+
+  test('DEFAULT_MEASURE_NAMES is wrapper-driven: every entry comes from Measure.getAllTypeNames()', () => {
+    // Adopting the Measure wrapper (ledger-models 0.1.138, PR #194)
+    // means a new proto enum entry upstream auto-propagates here
+    // without a UI-side edit. This assertion locks in the contract.
+    const wrapperNames = new Set(Measure.getAllTypeNames());
+    for (const name of DEFAULT_MEASURE_NAMES) {
+      expect(
+        wrapperNames.has(name),
+        `${name} should come from Measure.getAllTypeNames(); UI no longer hand-rolls the list`,
+      ).toBe(true);
+    }
   });
 
   test('DEFAULT_MEASURE_LABELS title-cases proto names', () => {


### PR DESCRIPTION
Adopts the new `Measure` wrapper from [ledger-models PR #194](https://github.com/FinTekkers/ledger-models/pull/194), mirroring the consumption pattern set by the prior wrapper rollouts:

| Wrapper | ledger-models PR | ui-service PR |
|---|---|---|
| Identifier | #188 | #134 |
| SecurityType + AssetClass | #189 | #136 |
| PositionFilterOperator | #190 | #144 |
| **Measure** | **#194** | **this PR** |

## Changes

**`package.json`** — `@fintekkers/ledger-models` `^0.1.135` → `^0.1.138`.

**`src/components/filters/MeasureMultiselectFilter.svelte`** — replace `Object.keys(MeasureProto)` iteration with `Measure.getAllTypeNames()`. Same single source of truth that drives `IDENTIFIER_TYPE_NAMES` / `SECURITY_TYPE_NAMES` / `ASSET_CLASS_NAMES` / `PositionFilterOperator` dropdowns — adding a new `Measure` proto entry upstream now propagates to this dropdown automatically.

**Friendly labels stay UI-side.** `DEFAULT_MEASURE_LABELS` (`DIRECTED_QUANTITY → 'Directed Quantity'`, etc.) remains a title-case derivation. Same disposition as the date-operator labels flagged in PR #144 / #149: the friendly-strings follow-up belongs upstream once the wrappers grow a description helper.

**`VALUATION_ONLY_MEASURES` exclusion stays.** It's a UI policy choice (positions search vs valuation search), not a vocabulary-ownership claim. Other consumers (a future valuation page) can pass a different `supportedMeasures` list to surface those entries.

## Review feedback addressed (commit `30bbdda`)

User flagged the original `Set<string>` definition as drift-prone:

> We should use strongly typed objects rather than strings here. We want to reduce potential for strings to become disconnected from the proto.

The amend swaps the Set to hold `MeasureProto` enum **values** directly:

```ts
const VALUATION_ONLY_MEASURES = new Set<MeasureProtoType>([
  MeasureProto.PRESENT_VALUE_CASHFLOWS,
  MeasureProto.PRESENT_VALUE,
  MeasureProto.REAL_YIELD,
  MeasureProto.INFLATION_ADJUSTED_PRINCIPAL,
  MeasureProto.DISCOUNT_MARGIN,
  MeasureProto.SPREAD_DURATION,
]);
```

If any of these proto entries gets renamed/removed upstream, the static reference **fails to compile** rather than silently no-op'ing at runtime. Lookup site uses `Measure.fromName()` to translate the wrapper's name strings into enum values — name resolution still goes through ledger-models's wrapper, no UI-side enum table.

The TS value-vs-type namespace collision (`const { MeasureProto } = ...` gives a value, but `Set<MeasureProto>` wants a type) is resolved with an aliased type-only import (`MeasureProtoType`) — same pattern as `FieldProto` / `FieldProtoType` in `positions.ts`.

`DEFAULT_LABELS` dict left as string-keyed — those are display strings, not proto identity comparisons; the drift concern doesn't apply.

## Tests

`src/components/filters/MeasureMultiselectFilter.test.ts` — existing 7 cases pass unchanged (proto names didn't change). One new contract test asserts **every** `DEFAULT_MEASURE_NAMES` entry comes from `Measure.getAllTypeNames()` — locks in "no UI-side hand-rolled list" going forward.

## Test plan

- [x] `npx svelte-check` — **83/205** unchanged from `main` baseline.
- [x] `npx vitest run` — 40/40 files, **561/561 passing** (+1 contract test).
- [x] `npx playwright test` — **33/33 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)