### PR TITLE
security: move /contactus Gmail SMTP creds to env vars (rotate the leaked App Password)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,16 @@
 GOOGLE_CLIENT_ID=your-dev-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-dev-client-secret
 
+# Contact-form SMTP (Gmail) — used by /contactus to email submissions.
+# Leave blank for local dev: the form fails-soft with a user-facing
+# "temporarily unavailable" message. Production injects via GH Actions
+# secrets CONTACT_GMAIL_USER / CONTACT_GMAIL_APP_PASSWORD.
+# CONTACT_GMAIL_APP_PASSWORD is a Gmail App Password (16-char string
+# from https://myaccount.google.com/apppasswords), NOT the account
+# password.
+CONTACT_GMAIL_USER=
+CONTACT_GMAIL_APP_PASSWORD=
+
 # API_URL=localhost forces gRPC calls to local services instead of api.fintekkers.org
 # This line is skipped by deploy_build.py for production deployments.
 API_URL=localhost

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,10 +36,17 @@ jobs:
       env:
         AWS_SERVER_KEYPAIR_BASE64: ${{ secrets.AWS_SERVER_KEYPAIR_BASE64 }}   
     - name: Run the script
-      run: python build_deploy.py 
+      run: python build_deploy.py
       env:
         GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
         GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+        # Contact form Gmail SMTP — required for /contactus.
+        # Configure as GH Actions repository secrets. App Password
+        # from https://myaccount.google.com/apppasswords (NOT the
+        # account password). If missing, the contact form fails-soft
+        # at runtime rather than crashing the page.
+        CONTACT_GMAIL_USER: ${{ secrets.CONTACT_GMAIL_USER }}
+        CONTACT_GMAIL_APP_PASSWORD: ${{ secrets.CONTACT_GMAIL_APP_PASSWORD }}
     - name: Delete server keypair
       run: | 
         rm -f ~/.aws/fintekkers-test-ec2.pem

--- a/build_deploy.py
+++ b/build_deploy.py
@@ -21,6 +21,11 @@ if os.path.exists(_env_path):
 
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+# Contact-form SMTP creds — Gmail App Password, NOT the account password.
+# Empty by default; the contact form fails-soft when unset (see
+# src/routes/contactus/+page.server.ts).
+CONTACT_GMAIL_USER = os.getenv("CONTACT_GMAIL_USER", "")
+CONTACT_GMAIL_APP_PASSWORD = os.getenv("CONTACT_GMAIL_APP_PASSWORD", "")
 
 
 SERVICE_NAME = "fintekkers-ui-service"
@@ -113,10 +118,15 @@ def deploy_code_to_instance(instance_id: str) -> bool:
         # The load balancer on AWS will add the encryption/certificate termination and forward
         # to this port. We could expose to port 80, but the broker is already using that port
         # Run the production server
+        # CONTACT_GMAIL_APP_PASSWORD contains spaces (the 4×4 group
+        # format Google emits), so single-quote-wrap it inside the
+        # outer double-quoted pm2 start argument.
         'cd /home/ec2-user/ui-service;sudo PORT=443 ORIGIN=https://www.fintekkers.org pm2 start "GOOGLE_CLIENT_ID='
         + GOOGLE_CLIENT_ID
         + " GOOGLE_CLIENT_SECRET="
         + GOOGLE_CLIENT_SECRET
+        + f" CONTACT_GMAIL_USER='{CONTACT_GMAIL_USER}'"
+        + f" CONTACT_GMAIL_APP_PASSWORD='{CONTACT_GMAIL_APP_PASSWORD}'"
         + ' npm run dev"',  # Needs sudo to expose host; currently running dev because the build fails... unsure why!!!
     ]
 

--- a/src/routes/contactus/+page.server.ts
+++ b/src/routes/contactus/+page.server.ts
@@ -10,6 +10,16 @@ const validationSchema = Yup.object({
     message: Yup.string().required('message'),
 });
 
+// Gmail SMTP credentials sourced from env vars. .env carries local-dev
+// values (or is empty, in which case the contact form fails-soft); GH
+// Actions secrets inject production values during deployment (see
+// build_deploy.py + .github/workflows/deploy.yml). Hardcoded
+// credentials were removed — the previously-committed app password
+// MUST be rotated in Gmail (the leak is in git history regardless of
+// this fix).
+const CONTACT_GMAIL_USER = process.env.CONTACT_GMAIL_USER ?? '';
+const CONTACT_GMAIL_APP_PASSWORD = process.env.CONTACT_GMAIL_APP_PASSWORD ?? '';
+
 export const actions = {
     message: async ({ request }) => {
         console.log("Will attempt to send mail");
@@ -26,19 +36,30 @@ export const actions = {
 
             await validationSchema.validate({ firstname, lastname, email, message }, { abortEarly: false });
 
+            if (!CONTACT_GMAIL_USER || !CONTACT_GMAIL_APP_PASSWORD) {
+                // Surface a user-facing error rather than try-then-throw
+                // against gmail (which would expose internals via the
+                // catch branch below). Server log carries the real reason.
+                console.error('Contact form: CONTACT_GMAIL_USER / CONTACT_GMAIL_APP_PASSWORD env vars not configured.');
+                return { formError: ['Contact form is temporarily unavailable. Please email us directly.'] };
+            }
+
             // Configure the transporter
             const transporter = nodemailer.createTransport({
                 service: "gmail", // or use host/port if using custom SMTP
                 auth: {
-                    user: "dave@fintekkers.org",         // replace with your real email
-                    pass: "epsm ntsw vpma zhsv"       // use app password if 2FA is on
+                    user: CONTACT_GMAIL_USER,
+                    pass: CONTACT_GMAIL_APP_PASSWORD,
                 }
             });
 
-            // Email content
+            // Email content. `to` mirrors the authenticated user
+            // (the form just routes inbound contact messages to
+            // whichever inbox the SMTP account belongs to) — one
+            // env var configures both sender and destination.
             const mailOptions = {
                 from: email,
-                to: "dave@fintekkers.org",
+                to: CONTACT_GMAIL_USER,
                 subject: `New message from ${firstname} ${lastname}`,
                 text: message,
                 html: `<p><strong>From:</strong> ${firstname} ${lastname} (${email})</p>


### PR DESCRIPTION
## 🚨 Action required outside this PR

A Gmail App Password was hardcoded in `src/routes/contactus/+page.server.ts:34` and committed to the public repo. **It must be rotated** at https://myaccount.google.com/apppasswords:
1. Revoke the App Password starting with `epsm…`.
2. Generate a new one.
3. Add the new value to GitHub Actions repository secrets as `CONTACT_GMAIL_APP_PASSWORD` (and `CONTACT_GMAIL_USER` for the matching account email).

This PR removes the value from the **working tree** but the leak is in **git history** regardless. App Password rotation is the lower-friction mitigation; a history rewrite (git filter-repo / BFG) is only worth the rewrite friction if the risk-rating warrants it.

## Changes

| File | Change |
|---|---|
| `src/routes/contactus/+page.server.ts` | Read `CONTACT_GMAIL_USER` + `CONTACT_GMAIL_APP_PASSWORD` from `process.env`. Fail-soft with a user-facing "temporarily unavailable" message when unset (server log carries the real reason). `to:` mirrors the authenticated user so one env var configures both sender + destination. |
| `.env.example` | Documents the new vars + the "App Password, NOT account password" caveat. Empty defaults — local dev works without contact-form sending. |
| `build_deploy.py` | Loads + forwards the new vars to the remote `pm2 start` command. `CONTACT_GMAIL_APP_PASSWORD` is single-quote-wrapped because the App Password format contains spaces (4×4 char groups). |
| `.github/workflows/deploy.yml` | Injects both new vars from GH Actions repository secrets during `build_deploy.py` execution. |

## Test plan

- [x] `npx svelte-check` — **83/205**, unchanged from `main` baseline.
- [x] grep for the leaked literal across `src/` + `tests/` + workflows — zero hits in working tree.
- [x] Local dev with empty `CONTACT_GMAIL_*`: form returns the user-facing error message; page doesn't crash.
- [ ] **Owner: rotate the App Password and add it to GH secrets BEFORE merging** so the new value is what lands in the deployment pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)