### PR TITLE
feat(M6 #263 bug 4): show portfolio name + UUID on /data/transactions

### DIFF
--- a/src/components/widgets/TransactionGrid.svelte
+++ b/src/components/widgets/TransactionGrid.svelte
@@ -23,9 +23,27 @@
   let sortField: keyof TransactionData | null = null;
   let sortDirection: SortDirection = "asc";
 
+  // M6 #263 bug 4: track which Portfolio ID cells the user has clicked to
+  // expand to the full UUID. Keyed by row.transactionPortfolioId so two rows
+  // for the same portfolio expand together (and the toggle survives a sort).
+  let expandedPortfolioIds = new Set<string>();
+  function togglePortfolioId(id: string) {
+    if (!id) return;
+    const next = new Set(expandedPortfolioIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    expandedPortfolioIds = next;
+  }
+  function compactUuid(id: string): string {
+    if (!id) return "";
+    return id.length > 8 ? `${id.slice(0, 8)}…` : id;
+  }
+
   // Column definitions with their corresponding TransactionData keys
   const columns: Array<{ label: string; key: keyof TransactionData }> = [
     { label: "ID", key: "transactionId" },
+    { label: "Portfolio", key: "transactionPortfolioName" },
+    { label: "Portfolio ID", key: "transactionPortfolioId" },
     { label: "Issuer Name", key: "transactionIssuerName" },
     { label: "Issue Date", key: "transactionIssueDate" },
     { label: "Maturity Date", key: "transactionMaturityDate" },
@@ -93,6 +111,19 @@
               <td class="table-cell px-4 py-2">
                 {#if column.key === "transactionQuantity"}
                   {formatAmount(row[column.key])}
+                {:else if column.key === "transactionPortfolioId"}
+                  {#if row.transactionPortfolioId}
+                    <button
+                      type="button"
+                      class="portfolio-id-toggle"
+                      title={expandedPortfolioIds.has(row.transactionPortfolioId)
+                        ? "Click to collapse"
+                        : row.transactionPortfolioId}
+                      on:click|stopPropagation={() => togglePortfolioId(row.transactionPortfolioId)}
+                    >{expandedPortfolioIds.has(row.transactionPortfolioId)
+                        ? row.transactionPortfolioId
+                        : compactUuid(row.transactionPortfolioId)}</button>
+                  {/if}
                 {:else}
                   {row[column.key]}
                 {/if}
@@ -168,6 +199,20 @@
 
   thead .action-col {
     background-color: #0c3a46;
+  }
+
+  .portfolio-id-toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #2563eb;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+    cursor: pointer;
+    text-decoration: underline dotted;
+
+    &:hover { color: #1d4ed8; }
+    &:focus { outline: 2px solid #3b82f6; outline-offset: 2px; }
   }
 
   .delete-btn {

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -47,6 +47,8 @@ function formatDateToISO(date: any): string {
 interface TransactionData {
   transactionId: string;
   uuidHex?: string;
+  transactionPortfolioId: string;
+  transactionPortfolioName: string;
   transactionSettlementDate: string;
   transactionIssuerName: string;
   transactionIssueDate: string;
@@ -102,6 +104,11 @@ let FetchTransactionWithFilter = async function FetchTransactionWithFilter(filte
         transactionData.push({
           transactionId: safe(() => security.getSecurityID().getIdentifierValue().toString(), ''),
           uuidHex,
+          // M6 #263 bug 4: surface the embedded portfolio so /data/transactions
+          // shows which portfolio each row belongs to. TransactionProto embeds
+          // a full PortfolioProto, so this is read directly from the wrapper.
+          transactionPortfolioId: safe(() => element.getPortfolio().getID().toString(), ''),
+          transactionPortfolioName: safe(() => element.getPortfolio().getPortfolioName(), ''),
           transactionSettlementDate: safe(() => formatDateToISO(element.getSettlementDate()), ''),
           transactionIssuerName: safe(() => element.getIssuerName().toString(), ''),
           transactionIssueDate: safe(() => formatDateToISO(security.getIssueDate()), ''),

--- a/src/tests/TransactionGrid.test.ts
+++ b/src/tests/TransactionGrid.test.ts
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+import TransactionGrid from '../components/widgets/TransactionGrid.svelte';
+import type { TransactionData } from '../lib/transactions';
+
+// M6 #263 bug 4: /data/transactions previously gave no indication which
+// portfolio each row belonged to. TransactionGrid now renders a 'Portfolio'
+// column (name) and a 'Portfolio ID' column (compact UUID, click-to-expand).
+
+const portfolioAUuid = '11111111-2222-3333-4444-555555555555';
+const portfolioBUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function row(overrides: Partial<TransactionData> = {}): TransactionData {
+  return {
+    transactionId: 'TXN-1',
+    uuidHex: 'deadbeef',
+    transactionPortfolioId: portfolioAUuid,
+    transactionPortfolioName: 'Growth Fund',
+    transactionSettlementDate: '2026-05-12',
+    transactionIssuerName: 'Treasury',
+    transactionIssueDate: '2026-01-01',
+    transactionQuantity: '1000',
+    transactionProductType: 'TREASURY_NOTE',
+    transactionTenor: '10Y',
+    transactionCouponFrequency: 'SEMI_ANNUAL',
+    transactionCouponRate: '0.045',
+    transactionCouponType: 'FIXED',
+    transactionMaturityDate: '2036-01-01',
+    transactionTradeDate: '2026-05-10',
+    transactionSide: 'BUY',
+    transactionPrice: '100',
+    ...overrides,
+  };
+}
+
+describe('TransactionGrid portfolio columns (M6 #263 bug 4)', () => {
+  test('renders Portfolio and Portfolio ID column headers', () => {
+    render(TransactionGrid, { props: { rows: [row()] } });
+    const headers = screen.getAllByRole('button').map((h) => h.textContent?.trim());
+    expect(headers).toContain('Portfolio');
+    expect(headers).toContain('Portfolio ID');
+  });
+
+  test('renders the portfolio name in every row', () => {
+    render(TransactionGrid, {
+      props: {
+        rows: [
+          row({ transactionId: 'TXN-A', transactionPortfolioName: 'Growth Fund' }),
+          row({ transactionId: 'TXN-B', transactionPortfolioName: 'Income Fund', transactionPortfolioId: portfolioBUuid }),
+        ],
+      },
+    });
+    expect(screen.getByText('Growth Fund')).toBeInTheDocument();
+    expect(screen.getByText('Income Fund')).toBeInTheDocument();
+  });
+
+  test('Portfolio ID displays compact (first 8 hex chars + …) by default', () => {
+    render(TransactionGrid, { props: { rows: [row()] } });
+    // First 8 chars of portfolioAUuid: '11111111'
+    const toggle = screen.getByRole('button', { name: /^11111111…$/ });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle.getAttribute('title')).toBe(portfolioAUuid);
+  });
+
+  test('clicking the compact Portfolio ID expands to the full UUID', async () => {
+    render(TransactionGrid, { props: { rows: [row()] } });
+    const toggle = screen.getByRole('button', { name: /^11111111…$/ });
+    await fireEvent.click(toggle);
+    expect(screen.getByRole('button', { name: portfolioAUuid })).toBeInTheDocument();
+  });
+
+  test('clicking expanded Portfolio ID collapses it back to compact', async () => {
+    render(TransactionGrid, { props: { rows: [row()] } });
+    const compact = screen.getByRole('button', { name: /^11111111…$/ });
+    await fireEvent.click(compact);
+    const expanded = screen.getByRole('button', { name: portfolioAUuid });
+    await fireEvent.click(expanded);
+    expect(screen.getByRole('button', { name: /^11111111…$/ })).toBeInTheDocument();
+  });
+
+  test('rows that share a portfolioId expand together (toggle keyed by id)', async () => {
+    render(TransactionGrid, {
+      props: {
+        rows: [
+          row({ transactionId: 'TXN-A' }),
+          row({ transactionId: 'TXN-B' }),
+        ],
+      },
+    });
+    const compactToggles = screen.getAllByRole('button', { name: /^11111111…$/ });
+    expect(compactToggles).toHaveLength(2);
+    await fireEvent.click(compactToggles[0]);
+    expect(screen.getAllByRole('button', { name: portfolioAUuid })).toHaveLength(2);
+  });
+
+  test('missing portfolioId renders no toggle button (empty cell)', () => {
+    render(TransactionGrid, {
+      props: { rows: [row({ transactionPortfolioId: '', transactionPortfolioName: '' })] },
+    });
+    expect(screen.queryByRole('button', { name: /…/ })).toBeNull();
+  });
+});

--- a/tests/e2e/transactions-portfolio-columns.spec.ts
+++ b/tests/e2e/transactions-portfolio-columns.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Playwright E2E for second-brain#263 bug 4: /data/transactions must expose
+ * the portfolio each row belongs to. TransactionGrid now renders a
+ * 'Portfolio' (name) column and a 'Portfolio ID' (compact-UUID,
+ * click-to-expand) column.
+ *
+ * Scope: with no portfolioId filter, the page loads ALL transactions and
+ * each row should show a non-empty Portfolio cell + a UUID toggle in the
+ * Portfolio ID cell.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('/data/transactions portfolio columns (#263 bug 4)', () => {
+  test('Portfolio + Portfolio ID column headers are present', async ({ page }) => {
+    await page.goto('/data/transactions');
+    await expect(page.getByRole('heading', { name: /Transactions/ })).toBeVisible({ timeout: 15_000 });
+
+    // Headers are clickable <th role="button"> elements. Match against the
+    // accessible-name-normalized text (sort indicator whitespace already
+    // collapses out of getByRole's name).
+    await expect(page.getByRole('button', { name: 'Portfolio', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Portfolio ID', exact: true })).toBeVisible();
+  });
+
+  test('at least one data row renders a non-empty Portfolio name + a Portfolio ID toggle', async ({ page }) => {
+    await page.goto('/data/transactions');
+    await expect(page.getByRole('heading', { name: /Transactions/ })).toBeVisible({ timeout: 15_000 });
+
+    const dataRows = page.locator('table tbody tr.table-row');
+    await expect(dataRows.first()).toBeVisible({ timeout: 15_000 });
+
+    // Resolve column indices from the header so the assertion survives
+    // future column reorders without false-positives.
+    const headerLabels = await page.locator('thead th').allTextContents();
+    const cleanLabels = headerLabels.map((s) => s.trim().replace(/[▲▼↕↑↓]\s*$/, '').trim());
+    const portfolioColIndex = cleanLabels.findIndex((l) => /^Portfolio$/i.test(l));
+    const portfolioIdColIndex = cleanLabels.findIndex((l) => /^Portfolio ID$/i.test(l));
+    expect(portfolioColIndex, 'Portfolio column present').toBeGreaterThanOrEqual(0);
+    expect(portfolioIdColIndex, 'Portfolio ID column present').toBeGreaterThanOrEqual(0);
+
+    const firstRow = dataRows.first();
+    const cells = firstRow.locator('td');
+    const portfolioName = (await cells.nth(portfolioColIndex).textContent() ?? '').trim();
+    expect(portfolioName.length, 'first row portfolio name is non-empty').toBeGreaterThan(0);
+
+    // Portfolio ID cell renders a clickable toggle whose title carries the
+    // full UUID. Compact form is first 8 hex chars + an ellipsis.
+    const toggle = cells.nth(portfolioIdColIndex).getByRole('button');
+    await expect(toggle).toBeVisible();
+    const title = await toggle.getAttribute('title');
+    expect(title, 'toggle title carries the full portfolio UUID').toMatch(
+      /^[0-9a-f-]{8}-[0-9a-f-]{4}-[0-9a-f-]{4}-[0-9a-f-]{4}-[0-9a-f-]{12}$/,
+    );
+    await expect(toggle).toHaveText(/^[0-9a-f]{8}…$/);
+
+    // Click expands the compact UUID to the full UUID.
+    await toggle.click();
+    await expect(toggle).toHaveText(title!);
+  });
+});


### PR DESCRIPTION
## Summary
- M6 smoke-test bug 4 (https://github.com/FinTekkers/second-brain/issues/263): `/data/transactions` previously gave no indication which portfolio each row belonged to.
- `TransactionProto` embeds a full `PortfolioProto` and the ledger-models 0.2.1 wrapper exposes `Transaction.getPortfolio()` → `Portfolio` with `getID()` and `getPortfolioName()`. No extra round-trip / no n+1 — the data is already on the wire.
- TransactionGrid now renders two new columns: **Portfolio** (name) and **Portfolio ID** (compact UUID; click to expand to the full UUID, keyed by portfolio so duplicate-portfolio rows toggle together and survive a sort).

## Files touched
- `src/lib/transactions.ts` — extend `TransactionData` with `transactionPortfolioId` + `transactionPortfolioName`, populated via `element.getPortfolio()` inside the existing per-row `try`/`safe()` guard.
- `src/components/widgets/TransactionGrid.svelte` — new columns + compact/expandable UUID toggle (button, dotted-underline, monospace).
- `src/tests/TransactionGrid.test.ts` — 7 new vitest cases (headers, name rendering, compact form, expand-on-click, collapse-on-click, multi-row co-toggle, empty-id no-render).
- `tests/e2e/transactions-portfolio-columns.spec.ts` — 2 playwright specs covering the headers and the first data row's Portfolio name + Portfolio ID toggle (asserting both compact form and title=full-UUID, then expand on click).

## Test plan
- [x] `npx vitest run src/tests/TransactionGrid.test.ts` — 7 tests pass
- [x] `npx vitest run` — full suite 574 pass / 10 todo / 0 fail
- [x] `npx playwright test tests/e2e/transactions-portfolio-columns.spec.ts` — 2 + setup pass
- [x] `npx svelte-check` — no new errors introduced; baseline pre-existing errors unchanged
- [x] Manual verification on live dev server: portfolio name + compact UUID render in every row; click expands; second click collapses

Note: the pre-existing `portfolio-soma-transactions.spec.ts` failure (SOMA scoping returns 0 rows) reproduces on `main` without my changes — it's an unrelated seed-data issue, not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)