### PR TITLE
fix(M6 #263 bug 6): wire /data/cpi_index to the post-M5 hierarchy

### DIFF
--- a/src/routes/(authenticated)/data/cpi_index/+page.server.ts
+++ b/src/routes/(authenticated)/data/cpi_index/+page.server.ts
@@ -8,6 +8,12 @@ import type { Identifier } from '@fintekkers/ledger-models/node/wrappers/models/
 import field_pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/field_pb.js';
 import { SecurityService } from '@fintekkers/ledger-models/node/wrappers/services/security-service/SecurityService';
 import { IndexTypeProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/index/index_type_pb';
+// M6 #263 bug 6: ProductTypeProto so we can post-filter on the CPI_SERIES
+// leaf. Pre-fix the server filter used asset_class='Index' (the abstract
+// parent product type, not a real asset_class), so the search matched
+// nothing and the page came back empty even though the ledger has
+// thousands of CPI prices for these series.
+import { ProductTypeProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/product_type_pb';
 
 const { FieldProto } = field_pkg;
 
@@ -38,21 +44,32 @@ function indexTypeToString(t: number): string {
 }
 
 async function fetchCpiSeries(apiKey?: string): Promise<CpiSeries[]> {
+  // M6 #263 bug 6: CPI_SERIES has asset_class=RATES + product_type=CPI_SERIES
+  // in hierarchy.json. Narrow server-side to RATES so we don't stream the
+  // whole security universe, then post-filter to CPI_SERIES below. The
+  // pre-fix filter used ASSET_CLASS='Index' — that's the *parent
+  // product_type* string ('INDEX'), not an asset_class value, so the
+  // search matched nothing and the page came back empty despite
+  // data-sourcing-dev confirming 4,798 CPI prices in the ledger.
   const filter = new PositionFilter();
-  filter.addEqualsFilter(FieldProto.ASSET_CLASS, 'Index');
+  filter.addEqualsFilter(FieldProto.ASSET_CLASS, 'RATES');
 
   const service = new SecurityService(apiKey);
   const securities = await service.searchSecurityAsOfNow(filter);
 
   const series: CpiSeries[] = [];
   for (const sec of securities) {
+    // Drop non-CPI rates leaves (TBILL, TIPS, TREASURY_BOND, SOFR_SERIES, …)
+    // before touching downstream getters.
+    if (sec.proto.getProductType() !== ProductTypeProto.CPI_SERIES) continue;
+
     const idProto = sec.proto.getIdentifier();
     const idValue = idProto?.getIdentifierValue();
     const indexTypeNum = sec.proto.getIndexType();
     const indexTypeStr = indexTypeToString(indexTypeNum);
 
-    // Filter to CPI families. Other Index-class securities (e.g. SOFR) wouldn't
-    // belong on this page even if they were ASSET_CLASS=Index.
+    // Filter to CPI families. CPI_SERIES is the parent product type;
+    // index_type narrows to the specific CPI variant the BLS publishes.
     if (indexTypeStr !== 'CPI_U' && indexTypeStr !== 'CORE_CPI' && indexTypeStr !== 'CPI_W' && indexTypeStr !== 'PCE' && indexTypeStr !== 'HICP') continue;
     if (!idValue) continue;
 

--- a/src/tests/cpi-index-display.test.ts
+++ b/src/tests/cpi-index-display.test.ts
@@ -153,14 +153,19 @@ describe('CPI Index page – server data pipeline', () => {
 		expect(pageServer).toContain('export async function load');
 	});
 
-	test('discovers CPI series via SecurityService (no hardcoded UUID)', () => {
+	test('discovers CPI series via SecurityService scoped to ASSET_CLASS=RATES + product_type=CPI_SERIES (M6 #263 bug 6)', () => {
 		// Server used to pin to a single hardcoded CPI-U UUID
-		// ('c7c719a1-7bbc-5890-992d-7f6f3a4b3dca'). Now it queries
-		// SecurityService for ASSET_CLASS=Index securities and filters
-		// to CPI-family index types — supports any BLS series the
-		// security service knows about.
+		// ('c7c719a1-7bbc-5890-992d-7f6f3a4b3dca'). The follow-up rewrite
+		// queried by ASSET_CLASS='Index' — but 'Index' is the abstract
+		// product_type parent, not an asset_class value, so the search
+		// returned zero rows and the page rendered empty despite the
+		// ledger holding thousands of CPI prices. Post-fix the filter
+		// uses ASSET_CLASS='RATES' (where CPI_SERIES lives per
+		// hierarchy.json) with a post-filter on product_type=CPI_SERIES.
 		expect(pageServer).toContain('SecurityService');
-		expect(pageServer).toContain("addEqualsFilter(FieldProto.ASSET_CLASS, 'Index')");
+		expect(pageServer).toContain("addEqualsFilter(FieldProto.ASSET_CLASS, 'RATES')");
+		expect(pageServer).toContain('ProductTypeProto.CPI_SERIES');
+		expect(pageServer).not.toContain("addEqualsFilter(FieldProto.ASSET_CLASS, 'Index')");
 		expect(pageServer).not.toContain('c7c719a1-7bbc-5890-992d-7f6f3a4b3dca');
 	});
 

--- a/tests/e2e/cpi-index-page-data.spec.ts
+++ b/tests/e2e/cpi-index-page-data.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * M6 #263 bug 6: /data/cpi_index returned no series and no historical
+ * data despite the ledger holding 4,798 CPI prices. The page-server's
+ * security filter used asset_class='Index' — that's the abstract
+ * product_type *parent*, not an asset_class value, so the search
+ * matched zero rows. Post-fix the page-server filters by
+ * asset_class='RATES' + post-filters by product_type=CPI_SERIES,
+ * which is where CPI_SERIES lives in hierarchy.json.
+ *
+ * Asserts both layers: the series picker is populated AND at least
+ * one historical CPI data point renders in the monthly-data table.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('/data/cpi_index — series + historical data (#263 bug 6)', () => {
+  test('series dropdown is non-empty and the historical table has data', async ({ page }) => {
+    await page.goto('/data/cpi_index');
+    await expect(page.getByRole('heading', { name: /CPI/i }).first()).toBeVisible({ timeout: 15_000 });
+
+    // The page-server picks DEFAULT_SERIES_ID = 'CUUR0000SA0' (BLS CPI-U All
+    // Items) when no ?series= is set. The dropdown should be populated and
+    // include CUUR0000SA0.
+    const seriesSelect = page.locator('#series-select');
+    await expect(seriesSelect).toBeVisible({ timeout: 10_000 });
+    await expect(seriesSelect).toBeEnabled();
+
+    const options = await seriesSelect.locator('option').allTextContents();
+    const seriesIds = options.map((o) => o.split('—')[0]?.trim()).filter(Boolean);
+    expect(seriesIds.length, 'series dropdown is non-empty').toBeGreaterThan(0);
+    expect(seriesIds.some((id) => /^CUUR/.test(id)), `at least one BLS CPI-U series surfaced (got: ${seriesIds.join(', ')})`).toBe(true);
+
+    // No "No CPI series" empty-state banner.
+    await expect(page.locator('.empty-state')).toHaveCount(0);
+
+    // The monthly-data table renders one row per observation. With 4,798
+    // CPI prices in the ledger, the default CPI-U series has hundreds of
+    // observations — assert a generous lower bound so this test isn't
+    // a flake risk if the seed shrinks.
+    const valueCells = page.locator('table td.value-cell');
+    await expect(valueCells.first()).toBeVisible({ timeout: 10_000 });
+    const count = await valueCells.count();
+    expect(count, 'monthly-data table renders historical CPI rows').toBeGreaterThan(10);
+
+    // Each value cell carries a 3-decimal numeric — sanity-check the
+    // formatting wires through.
+    const firstValue = (await valueCells.first().textContent() ?? '').trim();
+    expect(firstValue, 'CPI value renders numerically').toMatch(/^-?\d+\.\d{3}$/);
+  });
+});


### PR DESCRIPTION
## Summary
- M6 smoke-test bug 6 (https://github.com/FinTekkers/second-brain/issues/263): /data/cpi_index was empty despite the ledger holding 4,798 CPI prices.
- Root cause: the page-server filtered SecurityService by asset_class='Index', but 'INDEX' is the abstract product_type *parent* in hierarchy.json, not an asset_class value. CPI_SERIES has asset_class='RATES' per the registry.
- Fix: filter server-side by ASSET_CLASS='RATES' and post-filter by product_type=CPI_SERIES. The existing IndexType post-filter continues to narrow to CPI variants.

## Files touched
- `src/routes/(authenticated)/data/cpi_index/+page.server.ts` — fix the filter; import ProductTypeProto for the post-filter.
- `src/tests/cpi-index-display.test.ts` — update the data-pipeline assertion (previously pinned the broken `'Index'` string); now asserts both the new ASSET_CLASS='RATES' filter and the ProductTypeProto.CPI_SERIES post-filter.
- `tests/e2e/cpi-index-page-data.spec.ts` — new playwright spec asserting the series dropdown is populated with BLS CUUR… series AND that the monthly-data table renders historical CPI rows (>10 with 3-decimal numeric values).

## Test plan
- [x] `npx vitest run src/tests/cpi-index-display.test.ts` — 38 tests pass
- [x] `npx vitest run` — full suite 574 pass / 10 todo / 0 fail
- [x] `npx playwright test tests/e2e/cpi-index-page-data.spec.ts` — passes against live dev server
- [x] `npx svelte-check` — no new errors (87 baseline unchanged)
- [x] Manual on live server: CUUR0000SA0 (CPI-U) renders the Plotly chart + 1,359 monthly rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)