### PR TITLE
fix(#263): thread apiKey to /treasuries2 page-server (500 → 200)

### DIFF
--- a/src/routes/treasuries2/+page.server.ts
+++ b/src/routes/treasuries2/+page.server.ts
@@ -2,8 +2,13 @@ import { getTreasuryTransactions } from '$lib/treasury_positions';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ locals }) {
-  // Fetch treasury transactions with current date as asOfDate
-  const transactions = await getTreasuryTransactions(new Date('2026-01-01T00:59:59'));
+  // Thread apiKey through so the underlying PositionService.search goes via
+  // the broker's authenticated route. Without it the call fails with
+  // `16 UNAUTHENTICATED: API key required`. Same fix as 5d8f052 for /treasuries3.
+  const transactions = await getTreasuryTransactions(
+    new Date('2026-01-01T00:59:59'),
+    locals.user?.apiKey,
+  );
 
   return {
     transactions: transactions || [],

--- a/tests/e2e/treasuries2-loads.spec.ts
+++ b/tests/e2e/treasuries2-loads.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression for the /treasuries2 500 surfaced in second-brain#263. The
+ * page-server's load() called getTreasuryTransactions without threading
+ * locals.user?.apiKey, so the underlying gRPC search went out
+ * unauthenticated and the broker returned UNAUTHENTICATED — which load()
+ * re-threw, taking the whole page to a 500 before render.
+ *
+ * Identical pattern to the /treasuries3 fix in 5d8f052; that branch missed
+ * its sibling /treasuries2.
+ *
+ * After the fix the page should either render the analytics view
+ * (December 2025 data is in the seed) OR the empty-state — but never 500.
+ *
+ * /treasuries2 is a top-level route (NOT under (authenticated)/), so
+ * `.auth-shell` is not present here. Assert against the page's own H1.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('/treasuries2 — page-server apiKey threading', () => {
+  test('/treasuries2 loads without 500 (apiKey threaded to getTreasuryTransactions)', async ({ page }) => {
+    const response = await page.goto('/treasuries2');
+
+    expect(response, 'GET /treasuries2 returns a response').not.toBeNull();
+    const status = response!.status();
+    expect(status, 'no 500 / no 5xx after apiKey threading').toBeLessThan(500);
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Treasury Position Analytics/ }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Either the analytics view OR the empty-state is acceptable — both
+    // prove load() returned cleanly. Seed contents are backend-driven.
+    const graphs = page.locator('.graphs-column');
+    const emptyState = page.locator('.no-data');
+    const hasGraphs = await graphs.isVisible().catch(() => false);
+    const hasEmptyState = await emptyState.isVisible().catch(() => false);
+    expect(
+      hasGraphs || hasEmptyState,
+      'either the graphs column OR the empty-state is rendered',
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `/treasuries2/+page.server.ts:6` called `getTreasuryTransactions(asOf)` without forwarding `locals.user?.apiKey` → broker returned `16 UNAUTHENTICATED: API key required` → SvelteKit re-threw the error as a 500.
- Same root cause as the `/treasuries3` 500 fixed in 5d8f052; that PR missed its sibling. This patch closes the gap by threading `locals.user?.apiKey` through the call site.

## Why a one-line fix
The actual stack trace (from `~/second-brain/logs/ui-service.log` against authenticated traffic at 15:08 UTC) is:
```
Error: 16 UNAUTHENTICATED: API key required. Set the x-api-key metadata header.
  at streamSearch (src/lib/treasury_positions.ts:262:31)
  at Module.getTreasuryTransactions (src/lib/treasury_positions.ts:273:43)
  at load (src/routes/treasuries2/+page.server.ts:6:30)
```
`getTreasuryTransactions(asOfDate, apiKey?)` builds its gRPC connection via `getServiceConnection(apiKey)`. Without the second arg the connection is unauthenticated. No proto/wrapper drift involved — strictly the same auth-threading bug already fixed elsewhere.

## Test plan
- [x] `npx playwright test tests/e2e/treasuries2-loads.spec.ts tests/e2e/treasuries3-loads.spec.ts` — 3/3 green (auth.setup + treasuries2 + treasuries3 regressions)
- [x] `npx vitest run` — 580 passed / 10 todo / 0 failed
- [x] `npx svelte-check` — no new errors introduced on the touched files
- [ ] Manual smoke (PM): authenticated visit to `/treasuries2` renders Plotly graphs (or empty-state if the seed has no December-2025 transactions)

## Findings posted to second-brain#263
https://github.com/FinTekkers/second-brain/issues/263#issuecomment-4442689792 (then user clarified to fix rather than delete; this PR is the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)