### PR TITLE
fix(M6 #263 bug 3 round 2): coupon read for non-BondSecurity leaves (TREASURY_BOND/STRIPS/SOVEREIGN_BOND)

### DIFF
--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -103,6 +103,43 @@ export function productTypeNameOf(security: Security): string {
   return found?.[0] ?? 'UNKNOWN_PRODUCT_TYPE';
 }
 
+// M6 #263 bug 3 (second round): the ledger-models 0.2.4 `Security.create()`
+// factory wraps only TREASURY_NOTE / TIPS / TREASURY_FRN as a BondSecurity.
+// TREASURY_BOND, TBILL, STRIPS, and SOVEREIGN_BOND fall through to the base
+// `Security` wrapper — which has no `getCouponRate()`. Anything that calls
+// `(security as BondSecurity).getCouponRate()` on those leaves hits a
+// "...not a function" TypeError; the typical try/catch wrappers around the
+// call swallow it and surface `couponRate = 0` in the UI. That's how
+// /data/treasury_curve shows 0% for the 20Y on-the-run (a TREASURY_BOND
+// with a real 4.x% coupon on the wire).
+//
+// Read coupon_rate from the proto directly, preferring the bond_details /
+// tips_details / frn_details oneof (the modern path that data-sourcing-dev
+// writes — see #263 face_value + coupon backfill) and falling back to the
+// flat `SecurityProto.coupon_rate` legacy field. Returns 0 when neither is
+// populated, which is the correct semantic for TBILL (zero-coupon by
+// definition).
+export function couponRateOf(security: Security): number {
+  const parseRate = (rate: { getArbitraryPrecisionValue?: () => string } | undefined): number | undefined => {
+    if (!rate) return undefined;
+    const raw = rate.getArbitraryPrecisionValue?.();
+    if (raw === undefined || raw === null || raw === '') return undefined;
+    const n = parseFloat(raw);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  const proto: any = security.proto;
+  const details =
+    proto.getBondDetails?.() ||
+    proto.getTipsDetails?.() ||
+    proto.getFrnDetails?.() ||
+    undefined;
+  return (
+    parseRate(details?.getCouponRate?.()) ??
+    parseRate(proto.getCouponRate?.()) ??
+    0
+  );
+}
+
 function identifierTypeNameToProto(name: IdentifierTypeName): IdentifierTypeProto {
   switch (name) {
     case 'ISIN': return IdentifierTypeProto.ISIN;

--- a/src/lib/treasuryCurveSelection.ts
+++ b/src/lib/treasuryCurveSelection.ts
@@ -38,7 +38,7 @@ import { getServiceConnection } from '$lib/grpc-auth';
 // actually matches. Pre-fix, BondSecurity instances returned
 // 'BILL' / 'NOTE' / 'BOND' which is not in ON_THE_RUN_PRODUCT_TYPES,
 // silently rejecting every candidate from the on-the-run set.
-import { productTypeNameOf } from '$lib/security';
+import { productTypeNameOf, couponRateOf } from '$lib/security';
 
 const { FieldProto } = pkg;
 
@@ -171,11 +171,14 @@ export async function selectOnTheRunBonds(asOfDate: Date, apiKey?: string): Prom
           ? bond.getSecurityID().getIdentifierValue()
           : bond.getID().toString();
 
-        let couponRate = 0;
-        try {
-          const cr = bond.getCouponRate();
-          couponRate = cr ? parseFloat(cr.getArbitraryPrecisionValue()) : 0;
-        } catch { /* no coupon rate */ }
+        // couponRateOf reads from the bond/tips/frn details oneof (or the
+        // flat SecurityProto.coupon_rate fallback). Necessary because
+        // `Security.create()` returns a plain Security (not BondSecurity)
+        // for TREASURY_BOND / TBILL / STRIPS / SOVEREIGN_BOND, so calling
+        // (bond as BondSecurity).getCouponRate() on those throws and the
+        // 20Y on-the-run (a TREASURY_BOND) silently rendered 0% — M6 #263
+        // bug 3 second-round regression.
+        const couponRate = couponRateOf(bond);
 
         // productTypeNameOf — same reason as the filter above: avoid
         // the BondSecurity tenor-derived 'BILL'/'NOTE'/'BOND' override.

--- a/src/tests/couponRateOf.test.ts
+++ b/src/tests/couponRateOf.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit coverage for couponRateOf — the M6 #263 bug 3 (second round) fix.
+ *
+ * The picker for /data/treasury_curve was rendering coupon=0% for the 20Y
+ * on-the-run, a TREASURY_BOND with a real 4.x% coupon on the wire. Root
+ * cause: ledger-models 0.2.4's `Security.create()` factory only returns a
+ * BondSecurity wrapper for TREASURY_NOTE / TIPS / TREASURY_FRN. For
+ * TREASURY_BOND / TBILL / STRIPS / SOVEREIGN_BOND it returns a plain
+ * Security — which has no `getCouponRate()` method — and the picker's
+ * try/catch around `(bond as BondSecurity).getCouponRate()` swallowed the
+ * "not a function" TypeError, defaulting to 0.
+ *
+ * couponRateOf reads coupon_rate from the proto directly, trying the
+ * bond/tips/frn details oneof first (where data-sourcing-dev writes the
+ * canonical value post-M6) and falling back to the legacy flat field.
+ */
+import { describe, expect, test } from 'vitest';
+import { couponRateOf } from '$lib/security';
+
+// Fake Security wrappers — we only need the .proto field couponRateOf
+// reads. Avoids pulling in the full ledger-models wrapper construction
+// (which expects valid SecurityProto bytes / wire format).
+function fakeSecurity(stub: any) {
+  return { proto: stub } as any;
+}
+
+const decimal = (v: string) => ({ getArbitraryPrecisionValue: () => v });
+
+describe('couponRateOf', () => {
+  test('reads from bond_details.coupon_rate (the M6 canonical path)', () => {
+    const sec = fakeSecurity({
+      getBondDetails: () => ({ getCouponRate: () => decimal('4.625') }),
+      getTipsDetails: () => undefined,
+      getFrnDetails: () => undefined,
+      getCouponRate: () => undefined,
+    });
+    expect(couponRateOf(sec)).toBe(4.625);
+  });
+
+  test('reads from tips_details when bond_details is absent', () => {
+    const sec = fakeSecurity({
+      getBondDetails: () => undefined,
+      getTipsDetails: () => ({ getCouponRate: () => decimal('2.375') }),
+      getFrnDetails: () => undefined,
+      getCouponRate: () => undefined,
+    });
+    expect(couponRateOf(sec)).toBe(2.375);
+  });
+
+  test('reads from frn_details when only that oneof is set', () => {
+    const sec = fakeSecurity({
+      getBondDetails: () => undefined,
+      getTipsDetails: () => undefined,
+      getFrnDetails: () => ({ getCouponRate: () => decimal('0.125') }),
+      getCouponRate: () => undefined,
+    });
+    expect(couponRateOf(sec)).toBe(0.125);
+  });
+
+  test('falls back to the flat SecurityProto.coupon_rate (legacy data path)', () => {
+    const sec = fakeSecurity({
+      getBondDetails: () => undefined,
+      getTipsDetails: () => undefined,
+      getFrnDetails: () => undefined,
+      getCouponRate: () => decimal('3.875'),
+    });
+    expect(couponRateOf(sec)).toBe(3.875);
+  });
+
+  test('prefers details oneof when both flat and details are populated', () => {
+    // Real wire shape per data-sourcing-dev's #263 spot-check: post-M6
+    // backfill writes BOTH the flat field AND bond_details. The details
+    // value is the canonical one; the flat field is a legacy/dual-write
+    // residue. If they ever drift we want the canonical one to win.
+    const sec = fakeSecurity({
+      getBondDetails: () => ({ getCouponRate: () => decimal('4.625') }),
+      getTipsDetails: () => undefined,
+      getFrnDetails: () => undefined,
+      getCouponRate: () => decimal('0.0'),
+    });
+    expect(couponRateOf(sec)).toBe(4.625);
+  });
+
+  test('returns 0 for TBILL (no coupon anywhere — correct zero-coupon semantic)', () => {
+    const sec = fakeSecurity({
+      getBondDetails: () => undefined,
+      getTipsDetails: () => undefined,
+      getFrnDetails: () => undefined,
+      getCouponRate: () => undefined,
+    });
+    expect(couponRateOf(sec)).toBe(0);
+  });
+
+  test('returns 0 when the details proto exists but coupon_rate is empty', () => {
+    const sec = fakeSecurity({
+      getBondDetails: () => ({ getCouponRate: () => undefined }),
+      getTipsDetails: () => undefined,
+      getFrnDetails: () => undefined,
+      getCouponRate: () => undefined,
+    });
+    expect(couponRateOf(sec)).toBe(0);
+  });
+
+  test('returns 0 for unparseable rate strings rather than NaN', () => {
+    const sec = fakeSecurity({
+      getBondDetails: () => ({ getCouponRate: () => decimal('garbage') }),
+      getTipsDetails: () => undefined,
+      getFrnDetails: () => undefined,
+      getCouponRate: () => undefined,
+    });
+    expect(couponRateOf(sec)).toBe(0);
+  });
+
+  test('handles missing details accessors (stale JS codegen)', () => {
+    // Defensive: BondSecurity.js guards with `typeof getBondDetails !==
+    // 'function'`. We replicate that tolerance — if the proto wrapper
+    // is from an older ledger-models build, we should still read the
+    // flat field rather than crash.
+    const sec = fakeSecurity({
+      getCouponRate: () => decimal('5.0'),
+    });
+    expect(couponRateOf(sec)).toBe(5.0);
+  });
+
+  test('parses negative coupon (defensive — FRN spread floor can go negative)', () => {
+    const sec = fakeSecurity({
+      getBondDetails: () => undefined,
+      getTipsDetails: () => undefined,
+      getFrnDetails: () => ({ getCouponRate: () => decimal('-0.125') }),
+      getCouponRate: () => undefined,
+    });
+    expect(couponRateOf(sec)).toBe(-0.125);
+  });
+});

--- a/tests/e2e/treasury-curve-coupon-non-bond-leaves.spec.ts
+++ b/tests/e2e/treasury-curve-coupon-non-bond-leaves.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression for M6 #263 BUG 3 second-round: /data/treasury_curve renders
+ * coupon=0% on every TREASURY_BOND on-the-run (typical: the 20Y bucket)
+ * because `Security.create()` returns a plain Security wrapper for
+ * leaves the BondSecurity factory case statement doesn't cover —
+ * TREASURY_BOND, TBILL, STRIPS, SOVEREIGN_BOND — and the picker calls
+ * `(security as BondSecurity).getCouponRate()` which throws on the
+ * non-BondSecurity classes.
+ *
+ * After the fix, the 20Y row (TREASURY_BOND) must show a non-zero
+ * coupon if the underlying wire data has one. Data-sourcing-dev's
+ * #263 audit confirmed wire is populated (e.g. 912810UT3 = 4.625%).
+ *
+ * What this spec DOESN'T assert:
+ *  - The specific coupon value (varies with the on-the-run cycle).
+ *  - The 1M/3M/6M T-Bill rows showing 0% — TBills ARE zero-coupon by
+ *    definition, so the displayed "0.000%" is correct on those.
+ *  - TREASURY_FRN coupon: FRN coupons reset on a schedule; the wire
+ *    value may legitimately be 0 between resets. Out of scope for
+ *    this regression.
+ *
+ * If for the current cycle the 20Y bucket happens to be a TIPS or
+ * TREASURY_NOTE (still wrapped as BondSecurity, so unaffected by this
+ * bug), the spec falls through — it only asserts on rows whose
+ * productType is in the previously-broken set.
+ */
+import { test, expect } from '@playwright/test';
+
+const NON_BONDSECURITY_LEAVES = new Set(['TREASURY_BOND', 'STRIPS', 'SOVEREIGN_BOND']);
+
+test.describe('/data/treasury_curve — coupon read for non-BondSecurity leaves (#263 bug 3 round 2)', () => {
+  test('TREASURY_BOND / STRIPS / SOVEREIGN_BOND rows render their wire coupon, not 0%', async ({ page }) => {
+    await page.goto('/data/treasury_curve');
+    await expect(page.locator('table tbody')).toBeVisible({ timeout: 15_000 });
+
+    type Row = { tenor: string; cusip: string; description: string; coupon: string };
+    const rows: Row[] = await page.locator('table tbody tr').evaluateAll((trs) =>
+      trs.map((tr) => {
+        const c = Array.from(tr.querySelectorAll('td'));
+        return {
+          tenor:       c[0]?.textContent?.trim() ?? '',
+          cusip:       c[1]?.textContent?.trim() ?? '',
+          description: c[2]?.textContent?.trim() ?? '',
+          coupon:      c[5]?.textContent?.trim() ?? '',
+        };
+      }),
+    );
+
+    // Only assert on rows whose product-type leaf would have been broken
+    // by the BondSecurity-factory gap. Description format is e.g.
+    // "TREASURY_BOND 4.625% 2046-02-15".
+    const subject = rows.filter((r) =>
+      [...NON_BONDSECURITY_LEAVES].some((leaf) => r.description.startsWith(leaf + ' ')),
+    );
+
+    test.skip(subject.length === 0, 'no TREASURY_BOND / STRIPS / SOVEREIGN_BOND row in the current on-the-run pick — nothing to assert');
+
+    for (const r of subject) {
+      // The bug surfaced as exactly the string "0.000%". We assert it isn't
+      // that anymore for rows that should carry a wire coupon.
+      const couponNum = parseFloat(r.coupon.replace('%', ''));
+      expect(
+        couponNum,
+        `${r.cusip} (${r.tenor}, ${r.description.split(' ')[0]}) should have a wire coupon — saw "${r.coupon}"`,
+      ).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `/data/treasury_curve` renders coupon=0% on the 20Y on-the-run (a TREASURY_BOND that has a real 4.625% coupon on the wire). Same shape as the round-1 bug we thought PR #158 closed, but coming from a different angle now that data-sourcing-dev has TREASURY_BOND coupon_rate populated.
- Root cause: ledger-models 0.2.4 `Security.create()` returns a plain Security (not BondSecurity) for TREASURY_BOND / TBILL / STRIPS / SOVEREIGN_BOND. The picker's `(bond as BondSecurity).getCouponRate()` throws `TypeError: not a function` on those instances; the surrounding try/catch swallows it and defaults to 0. TBills happen to be zero-coupon so 0% there is correct by accident.
- Fix: new `couponRateOf(security)` in `$lib/security.ts` reads coupon_rate from the proto directly (bond/tips/frn details oneof, then flat field). Picker switches to it. No call-site signature change.

## Before / after
| Row | Pre-fix | Post-fix |
|---|---|---|
| 20Y (TREASURY_BOND 912810UT3) | `TREASURY_BOND 0% 2046-02-15` — coupon `0.000%` | `TREASURY_BOND 4.625% 2046-02-15` — coupon `4.625%` |
| 1M/3M/6M/1Y TBills | `0.000%` | `0.000%` (correct — zero-coupon) |
| 3Y/5Y/7Y/10Y/30Y notes & TIPS | correct (BondSecurity path) | unchanged |

(Wire values cross-checked against data-sourcing-dev's #263 audit comment.)

## Tests
- [x] `src/tests/couponRateOf.test.ts` — 10 unit tests (vitest): bond/tips/frn details, flat-field fallback, oneof-vs-flat precedence, empty rate, garbage rate, missing accessors (stale codegen), negative rate.
- [x] `tests/e2e/treasury-curve-coupon-non-bond-leaves.spec.ts` — asserts every TREASURY_BOND / STRIPS / SOVEREIGN_BOND row on the live page has a non-zero coupon. Skips if no such row in the current on-the-run cycle.
- [x] `npx vitest run` → 600 passed / 10 todo / 0 failed
- [x] `npx svelte-check` → 78 errors / 205 warnings (unchanged from main)

## Out of scope
- The 3M row's missing clean price (CUSIP 912797VB0): bitemporal residual that data-sourcing-dev called out + cleaned up in their #263 comment. Not a UI bug.
- TREASURY_FRN coupon showing 0%: FRN coupons reset on a schedule and the wire value may legitimately be 0 between resets; data-sourcing-dev didn't include FRN in their wire-audit table. Separate scope.
- BUG 4 (`?asof=2026-05-01&term=10`): investigated separately on #263 — not a #161 regression, shares the data-sourcing pool that this PR partially mitigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)