### PR TITLE
fix(#263 bug 1): catch position-search gRPC errors on /data/positions (SOMA link 500 → 200)

### DIFF
--- a/src/routes/(authenticated)/data/positions/+page.server.ts
+++ b/src/routes/(authenticated)/data/positions/+page.server.ts
@@ -183,20 +183,38 @@ export async function load({ locals, request }) {
     validSortDirection = sortDirection === 'desc' ? 'desc' : 'asc';
   }
 
-  const positions = await FetchPosition(
-    requestData,
-    positionViewEnumValue,
-    positionTypeEnumValue,
-    mappedSortBy,
-    validSortDirection,
-    identifier || undefined,
-    tradeDate || undefined,
-    tradeDateOperator ?? undefined,
-    assetClass || undefined,
-    portfolioId || undefined,
-    locals.user?.apiKey,
-    identifierType,
-  );
+  // The position-search aggregates measures via valuation-service, and
+  // valuation-service throws INVALID_ARGUMENT on partial security data
+  // (e.g. "FRN requires spread on security" when an FRN in the portfolio
+  // is missing its spread field). A single such security in the requested
+  // portfolio used to take down the whole page render with a SvelteKit
+  // 500 — surfaced as M6 #263 bug 1 (SOMA portfolio link). Catch the
+  // gRPC error here and surface it as a structured page-level message so
+  // the rest of the page (autocomplete, header, back link) still renders.
+  let positions: any = [];
+  let fetchError: string | null = null;
+  try {
+    positions = await FetchPosition(
+      requestData,
+      positionViewEnumValue,
+      positionTypeEnumValue,
+      mappedSortBy,
+      validSortDirection,
+      identifier || undefined,
+      tradeDate || undefined,
+      tradeDateOperator ?? undefined,
+      assetClass || undefined,
+      portfolioId || undefined,
+      locals.user?.apiKey,
+      identifierType,
+    );
+  } catch (e: any) {
+    const detail = e?.details || e?.message || String(e);
+    console.error('Error fetching positions:', detail);
+    fetchError = detail
+      ? `Could not load positions: ${detail}`
+      : 'Could not load positions (backend returned an empty error).';
+  }
 
   const metadata = { fields: userFields, measures: userMeasures };
   return {
@@ -207,6 +225,7 @@ export async function load({ locals, request }) {
     portfolioId: portfolioId || null,
     portfolioName,
     portfolioUniverse,
+    error: fetchError,
     user: locals.user
   };
 }

--- a/src/routes/(authenticated)/data/positions/+page.svelte
+++ b/src/routes/(authenticated)/data/positions/+page.svelte
@@ -80,6 +80,12 @@
   initialPortfolioName={data.portfolioName ?? ''}
 />
 
+{#if data.error}
+  <div class="error-banner" role="alert">
+    {data.error}
+  </div>
+{/if}
+
 {#if $navigating}
   <div class="loading-container">
     <div class="spinner" />
@@ -144,5 +150,14 @@
     padding: 4rem 1rem;
     color: #94a3b8;
     font-size: 1.1rem;
+  }
+
+  .error-banner {
+    margin: 1rem;
+    padding: 0.75rem 1rem;
+    background-color: #7f1d1d;
+    color: #fecaca;
+    border-radius: 4px;
+    font-size: 0.9rem;
   }
 </style>

--- a/tests/e2e/positions-soma-error-graceful.spec.ts
+++ b/tests/e2e/positions-soma-error-graceful.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression for M6 #263 BUG 1 (second round): /data/portfolios →
+ * click "Federal Reserve SOMA Holdings" → /data/positions?... 500'd
+ * the whole page when the position-search aggregator's downstream
+ * valuation call threw an INVALID_ARGUMENT on any security in the
+ * portfolio (concrete trigger: "FRN requires spread on security" for
+ * a TREASURY_FRN with no spread field populated).
+ *
+ * The page-server's FetchPosition call was un-caught; SvelteKit
+ * promoted the gRPC exception to a 500. After the fix the page must
+ * still render — back link, autocomplete, header — with the gRPC
+ * error surfaced as a banner the user can act on.
+ *
+ * What this spec covers:
+ *   1. The page returns 200, NOT 500, for the SOMA portfolio link.
+ *   2. The page-content shell is present (the back-to-portfolios
+ *      link and the PositionSelect autocomplete).
+ *   3. If the live backend currently emits the FRN-spread error, the
+ *      banner is visible AND mentions the upstream cause. If the
+ *      backend is healthy (e.g. data-sourcing-dev backfilled FRN
+ *      spread), the positions table renders instead — we accept
+ *      either outcome so the spec doesn't bind on a data-side fix.
+ */
+import { test, expect } from '@playwright/test';
+
+const SOMA_POSITIONS_URL =
+  '/data/positions?portfolioId=c3f1fa15-09a6-4a36-85b0-b7fa7129f6a7' +
+  '&fields=SECURITY_DESCRIPTION%2CPORTFOLIO_NAME' +
+  '&measures=DIRECTED_QUANTITY%2CMARKET_VALUE%2CPROFIT_LOSS%2CCURRENT_YIELD%2CYIELD_TO_MATURITY' +
+  '&positionView=DEFAULT_VIEW&positionType=TRANSACTION' +
+  '&tradeDate=2026-05-13&tradeDateOperator=LESS_THAN_OR_EQUALS&hideZeros=true';
+
+test.describe('/data/positions — SOMA portfolio link survives backend gRPC errors (#263 bug 1)', () => {
+  test('200 + error banner OR table; never 500', async ({ page }) => {
+    const response = await page.goto(SOMA_POSITIONS_URL);
+    expect(response, 'GET /data/positions returns a response').not.toBeNull();
+    expect(response!.status(), 'no 500/5xx — page-server must catch the gRPC error').toBeLessThan(500);
+
+    // Shell renders regardless of backend state.
+    await expect(page.getByRole('link', { name: /Back to Portfolios/ }))
+      .toBeVisible({ timeout: 10_000 });
+
+    const banner = page.locator('.error-banner');
+    const positionGrid = page.locator('[data-testid="position-grid"], table');
+    const emptyState = page.locator('.empty-state');
+
+    const bannerVisible = await banner.isVisible().catch(() => false);
+    const gridVisible = await positionGrid.first().isVisible().catch(() => false);
+    const emptyVisible = await emptyState.isVisible().catch(() => false);
+
+    expect(
+      bannerVisible || gridVisible || emptyVisible,
+      'page renders an error banner OR a position grid OR an empty-state — not a SvelteKit 500',
+    ).toBe(true);
+
+    if (bannerVisible) {
+      const text = (await banner.textContent()) ?? '';
+      expect(text, 'banner explains the failure').toMatch(/Could not load positions/i);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- /data/portfolios → click "Federal Reserve SOMA Holdings" → /data/positions?portfolioId=c3f1fa15... 500'd hard. SvelteKit propagated an un-caught gRPC error from `FetchPosition` to an Internal Error page.
- Wrap the call in try/catch; surface a structured error in `data.error`; render an `.error-banner` while keeping the back-link + autocomplete shell intact.

## Root cause (captured via ledger-service log)
The PM URL requests `MARKET_VALUE` + friends. Computing those aggregates positions and calls valuation-service per security. The SOMA portfolio contains a TREASURY_FRN whose `spread` field is empty on the wire; valuation-service throws:

```
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: FRN requires spread on security
  at PositionAggregator.addMarketValue(PositionAggregator.java:314)
```

position-service strips the detail (the UI sees a bare `2 UNKNOWN:`), so a single bad security was taking the whole page down.

## Before / after
- Pre-fix: `GET /data/positions?portfolioId=c3f1fa15...` → **500 Internal Error**.
- Post-fix: `GET /data/positions?portfolioId=c3f1fa15...` → **200**; banner reads `Could not load positions: 2 UNKNOWN:`; back-link + autocomplete shell still render.

## Backend follow-ups (out of scope for this PR — flagged for dispatch)
1. valuation-service throws on empty FRN.spread is correct validation; the position-service aggregator should skip market-value computation for the offending security rather than failing the entire batch. **owner: backend-dev-ledger**
2. data-sourcing-dev's #263 backfills covered face_value + coupon_rate but not FRN.spread. **owner: data-sourcing-dev**
3. broker strips the gRPC error detail so the UI banner can't show the actionable text. **owner: backend-dev (broker)**

## Tests
- [x] `tests/e2e/positions-soma-error-graceful.spec.ts` — GETs the exact PM SOMA URL; asserts HTTP < 500 + back-link visible + (banner OR grid OR empty-state). Doesn't pin banner text so a data-side fix won't break the spec.
- [x] `npx vitest run` → 590 passed / 10 todo / 0 failed
- [x] `npx svelte-check` → 78 errors / 205 warnings (unchanged from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)