### PR TITLE
docs(#277): v0.4.0 SecurityProto call-site audit (Phase 5 prep)

### DIFF
--- a/docs/v0.4.0-call-site-audit.md
+++ b/docs/v0.4.0-call-site-audit.md
@@ -1,0 +1,271 @@
+# ui-service v0.4.0 SecurityProto Call-Site Audit (Phase 5 prep)
+
+Tracks the migration work the ui-service has to do once ledger-models PR #216
+(`feat(security)!: remove 17 flat fields, structured-shape only`) lands as v0.4.0.
+
+Sources of truth:
+- second-brain issue: https://github.com/FinTekkers/second-brain/issues/277
+- ledger-models PR (open): https://github.com/FinTekkers/ledger-models/pull/216
+- ledger-models PR head SHA at audit time: `d9c65aa` on the ledger-models-rust
+  bindings (commit `Wed May 13 22:26:16 2026`)
+
+## Scope
+
+This is a **doc-only** audit. No code changes in this PR — implementation
+moves to Phase 5 once v0.4.0 publishes and the ledger-service / market-data
+loaders have repopulated DB rows with the structured shape (`BondDetailsProto`
+/ `TipsExtensionProto` / `FrnExtensionProto` / `IndexDetailsProto` /
+`CashDetailsProto`).
+
+Audit covers `src/lib/**` and `src/routes/**`. Tests (`src/tests/**`,
+`tests/**`) are excluded — they'll move with the production call sites in the
+same Phase-5 PR.
+
+## The 17 fields and their new homes
+
+| Tag | Removed flat field | New canonical home |
+|---:|---|---|
+| 40 | `identifier` (already deprecated) | `identifiers[0]` (repeated, tag 42) |
+| 50 | `cash_id` | `CashDetailsProto.cash_id` |
+| 60 | `coupon_rate` | `BondDetailsProto.coupon_rate` |
+| 61 | `coupon_type` | `BondDetailsProto.coupon_type` |
+| 62 | `coupon_frequency` | `BondDetailsProto.coupon_frequency` |
+| 63 | `dated_date` | `BondDetailsProto.dated_date` |
+| 64 | `face_value` | `BondDetailsProto.face_value` |
+| 65 | `issue_date` | `BondDetailsProto.issue_date` |
+| 66 | `maturity_date` | `BondDetailsProto.maturity_date` |
+| 67 | `issuance_info` | `BondDetailsProto.issuance_info` |
+| 70 | `base_cpi` | `TipsExtensionProto.base_cpi` |
+| 71 | `index_date` | `TipsExtensionProto.index_date` |
+| 72 | `inflation_index_type` | `TipsExtensionProto.inflation_index_type` |
+| 80 | `index_type` | `IndexDetailsProto.index_type` |
+| 90 | `spread` | `FrnExtensionProto.spread` |
+| 91 | `reference_rate_index` | `FrnExtensionProto.reference_rate_index` |
+| 92 | `reset_frequency` | `FrnExtensionProto.reset_frequency` |
+
+## Categories
+
+Every call site falls into one of three buckets. Phase-5 work touches **only**
+RAW_PROTO_READ and WRITE_SIDE; WRAPPER_READ sites are stable.
+
+- **WRAPPER_READ** — call goes through the `Security` / `BondSecurity` wrapper
+  classes from `@fintekkers/ledger-models/.../wrappers/...`. PR #216 has already
+  taken the flat-fallback branch out of the wrapper internals; the wrapper's
+  caller-facing API is unchanged, so these sites need no edit.
+  **At-rest risk**: if any persisted row still carries only flat fields after
+  the migration, the wrapper returns null. That's a DB-layer concern, not a
+  ui-service code concern.
+- **RAW_PROTO_READ** — code calls a getter directly on
+  `security.proto` / `sec.proto` etc. These methods disappear in v0.4.0; the
+  call site must move to the structured oneof getter.
+- **WRITE_SIDE** — code builds a `SecurityProto` and calls a flat setter.
+  These setters disappear; the call must build the structured sub-message
+  (`BondDetailsProto`, `TipsExtensionProto`, `FrnExtensionProto`) and attach
+  it via `setBondDetails()` / `setTipsDetails()` / `setFrnDetails()`.
+
+## Fan-out helpers (single point of migration, multiple call sites)
+
+Two helpers in `src/lib/security.ts` are dual-read today (try structured, fall
+back to flat). Migrating them once removes the dead flat branch and cascades
+to every caller — no caller-side edits needed.
+
+| Helper | File:line | Flat fallback line(s) | Callers (in src/) |
+|---|---|---|---|
+| `baseCpiOf(security)` | `src/lib/security.ts:137` | `:143` reads `proto.getBaseCpi?.()` | `src/lib/security.ts:472`, `src/lib/security.ts:541` |
+| `couponRateOf(security)` | `src/lib/security.ts:150` | `:166` reads `proto.getCouponRate?.()` | `src/lib/treasuryCurveData.ts:104`, `src/lib/security.ts:472`, `src/lib/security.ts:541` |
+
+**Phase-5 action**: delete the flat-fallback line in each helper, drop the
+ternary, return only the structured read. No caller changes.
+
+> Note: both helpers use optional chaining (`proto.getBaseCpi?.()`), so they
+> won't throw after v0.4.0 strips the methods from the JS class — the missing
+> method simply yields `undefined`, the helper returns `undefined`, and the
+> caller behaves as if the row had no flat value (which is the correct
+> end-state). The dead branch is a hygiene/clarity cleanup, not a correctness
+> fix.
+
+## Call sites — must migrate
+
+### RAW_PROTO_READ (5 sites across 4 files + 2 inside fan-out helpers above)
+
+| File:line | Current code | Structured replacement |
+|---|---|---|
+| `src/lib/security.ts:323` | `const issuanceList = security.proto.getIssuanceInfoList();` | `security.proto.getBondDetails()?.getIssuanceInfoList()` |
+| `src/lib/security.ts:356` | `const idProto = security.proto.getIdentifier ? security.proto.getIdentifier() : null;` | `security.proto.getIdentifiersList()[0] ?? null` |
+| `src/lib/security.ts:371-372` | `const settlementSec = (security.proto as any).getSettlementCurrency?.();`<br>`settlementCurrency = settlementSec?.getCashDetails?.()?.getCashId?.() ?? '';` | This one **already reads via the structured path** (`getCashDetails().getCashId()`). `getSettlementCurrency` itself is not in the removal list. No change needed — re-classify as WRAPPER_READ. |
+| `src/lib/security.ts:500` | `const idProto = security.proto.getIdentifier ? security.proto.getIdentifier() : null;` | `security.proto.getIdentifiersList()[0] ?? null` |
+| `src/lib/transactions.ts:121` | `security.proto.getCouponRate()?.getArbitraryPrecisionValue() ?? ''` | `security.proto.getBondDetails()?.getCouponRate()?.getArbitraryPrecisionValue() ?? ''` (or replace with `couponRateOf(security)`) |
+| `src/lib/valuation.ts:469` | `const protoBaseCpiStr = securityProto.getBaseCpi?.()?.getArbitraryPrecisionValue?.();` | `securityProto.getTipsDetails()?.getBaseCpi()?.getArbitraryPrecisionValue()` |
+| `src/routes/+page.server.ts:48` | `let issuanceList = security.proto.getIssuanceInfoList();` | `security.proto.getBondDetails()?.getIssuanceInfoList() ?? []` |
+| `src/routes/(authenticated)/data/cpi_index/+page.server.ts:66` | `const idProto = sec.proto.getIdentifier();` | `sec.proto.getIdentifiersList()[0]` |
+| `src/routes/(authenticated)/data/cpi_index/+page.server.ts:68` | `const indexTypeNum = sec.proto.getIndexType();` | `sec.proto.getIndexDetails()?.getIndexType()` |
+| `src/routes/treasuries/+page.server.ts:196` | `security.proto.getCouponRate()?.getArbitraryPrecisionValue() ?? ''` | `security.proto.getBondDetails()?.getCouponRate()?.getArbitraryPrecisionValue() ?? ''` |
+
+### WRITE_SIDE (14 sites, all in `src/lib/valuation.ts`)
+
+`valuation.ts` builds three flavors of `SecurityProto` for the bond / TIPS / FRN
+pricer paths. Each builder currently calls flat setters; under v0.4.0 each must
+construct the right sub-details proto, populate fields on it, then attach via
+the structured setter.
+
+#### Bond pricer (`runBondValuation` / `runTreasuryValuation`)
+
+Lines 227, 231, 234, 242, 245, 249.
+
+```ts
+// Today
+security.setFaceValue(decimalValue(inputs.faceValue));
+security.setCouponRate(decimalValue(inputs.couponRate));
+security.setCouponType(CouponTypeProto.FIXED);
+security.setCouponFrequency(/* map */);
+security.setIssueDate(localDateFromString(inputs.issueDate).toProto());
+security.setMaturityDate(localDateFromString(inputs.maturityDate).toProto());
+
+// Phase 5
+const bondDetails = new BondDetailsProto();
+bondDetails.setFaceValue(decimalValue(inputs.faceValue));
+bondDetails.setCouponRate(decimalValue(inputs.couponRate));
+bondDetails.setCouponType(CouponTypeProto.FIXED);
+bondDetails.setCouponFrequency(/* map */);
+bondDetails.setIssueDate(localDateFromString(inputs.issueDate).toProto());
+bondDetails.setMaturityDate(localDateFromString(inputs.maturityDate).toProto());
+security.setBondDetails(bondDetails);
+```
+
+#### TIPS pricer (`runTipsValuation`)
+
+Lines 382, 386, 389, 397, 400, 404, 408, 446 (override path), 449 (input path).
+
+```ts
+// Today: mix of bond-shape fields on SecurityProto + setBaseCpi on
+// SecurityProto + setBaseCpi on (newly-constructed) TipsExtensionProto
+
+// Phase 5: bond-shape goes on BondDetailsProto (TIPS uses inherited bond
+// fields), inflation fields on TipsExtensionProto, both attached on the
+// SecurityProto via setBondDetails + setTipsDetails.
+const bondDetails = new BondDetailsProto();
+bondDetails.setFaceValue(/* ... */);
+bondDetails.setCouponRate(/* real coupon */);
+bondDetails.setCouponType(CouponTypeProto.FIXED);
+bondDetails.setCouponFrequency(/* map */);
+bondDetails.setIssueDate(/* ... */);
+bondDetails.setMaturityDate(/* ... */);
+security.setBondDetails(bondDetails);
+
+const tips = new TipsExtensionProto();
+tips.setBaseCpi(decimalValue(inputs.referenceCpi.trim()));
+security.setTipsDetails(tips);
+```
+
+Note: line 446 (`securityProto.setBaseCpi(baseCpiOverride)`) and line 449
+(`tipsDetails.setBaseCpi(...)`) are part of the #266 reference-CPI auto-populate
+override path. Today both branches exist (set on SecurityProto and set on
+TipsExtensionProto). Phase 5 keeps only the TipsExtensionProto branch.
+
+#### FRN pricer (`runFrnValuation`)
+
+Lines 524, 528, 535, 537, 545, 548, 556.
+
+```ts
+// Today
+security.setFaceValue(decimalValue(inputs.faceValue));
+security.setSpread(decimalValue(inputs.spread));
+security.setCouponRate(decimalValue((refRate + spreadPct).toString()));
+security.setCouponType(CouponTypeProto.FLOAT);
+security.setCouponFrequency(/* map */);
+security.setMaturityDate(localDateFromString(inputs.maturityDate).toProto());
+security.setReferenceRateIndex(/* map */);
+
+// Phase 5
+const bondDetails = new BondDetailsProto();
+bondDetails.setFaceValue(/* ... */);
+bondDetails.setCouponRate(/* ref + spread */);
+bondDetails.setCouponType(CouponTypeProto.FLOAT);
+bondDetails.setCouponFrequency(/* map */);
+bondDetails.setMaturityDate(/* ... */);
+security.setBondDetails(bondDetails);
+
+const frn = new FrnExtensionProto();
+frn.setSpread(decimalValue(inputs.spread));
+frn.setReferenceRateIndex(/* map */);
+security.setFrnDetails(frn);
+```
+
+## Call sites — no change needed (WRAPPER_READ)
+
+These call through the wrapper API and remain valid after v0.4.0. Listed for
+verification completeness only.
+
+| File:line | Code | Wrapper getter |
+|---|---|---|
+| `src/lib/security.ts:332` | `maturityDate = security.getMaturityDate().toDate();` | `Security.getMaturityDate()` |
+| `src/lib/security.ts:333` | `issueDate = security.getIssueDate().toDate();` | `Security.getIssueDate()` |
+| `src/lib/security.ts:433` | `const couponRate = bondSecurity.getCouponRate();` | `BondSecurity.getCouponRate()` |
+| `src/lib/security.ts:440` | `result.couponType = bondSecurity.getCouponType().name();` | `BondSecurity.getCouponType()` |
+| `src/lib/security.ts:446` | `result.couponFrequency = bondSecurity.getCouponFrequency()?.toString();` | `BondSecurity.getCouponFrequency()` |
+| `src/lib/security.ts:452` | `const faceValue = bondSecurity.getFaceValue();` | `BondSecurity.getFaceValue()` |
+| `src/lib/security.ts:459` | `const datedDate = bondSecurity.getDatedDate();` | `BondSecurity.getDatedDate()` |
+| `src/lib/security.ts:498` | `const maturityDate = security.getMaturityDate().toDate();` | `Security.getMaturityDate()` |
+| `src/lib/security.ts:499` | `const issueDate = security.getIssueDate().toDate();` | `Security.getIssueDate()` |
+| `src/lib/security.ts:534` | `result.couponRate = bondSecurity.getCouponRate()?.getArbitraryPrecisionValue();` | `BondSecurity.getCouponRate()` |
+| `src/lib/security.ts:536` | `result.faceValue = bondSecurity.getFaceValue()?.getArbitraryPrecisionValue();` | `BondSecurity.getFaceValue()` |
+| `src/lib/security.ts:538` | `const dd = bondSecurity.getDatedDate();` | `BondSecurity.getDatedDate()` |
+| `src/lib/treasuryCurveData.ts:87` | `issueDate = security.getIssueDate()?.toDate() ?? null;` | `Security.getIssueDate()` |
+| `src/lib/treasuryCurveData.ts:88` | `maturityDate = security.getMaturityDate()?.toDate() ?? null;` | `Security.getMaturityDate()` |
+| `src/lib/transactions.ts:118` | `safe(() => formatDateToISO(security.getIssueDate()), '')` | `Security.getIssueDate()` |
+| `src/lib/transactions.ts:122` | `safe(() => bondSecurity?.getCouponType().name() ?? '', '')` | `BondSecurity.getCouponType()` |
+| `src/lib/transactions.ts:124` | `safe(() => bondSecurity?.getCouponFrequency()?.toString() ?? '', '')` | `BondSecurity.getCouponFrequency()` |
+| `src/lib/transactions.ts:125` | `safe(() => formatDateToISO(security.getMaturityDate()), '')` | `Security.getMaturityDate()` |
+| `src/routes/+page.server.ts:55` | `security.getMaturityDate().toDate().getFullYear() > 2009` | `Security.getMaturityDate()` |
+| `src/routes/+page.server.ts:59` | `security.getMaturityDate().toDate().getFullYear() <= 2009` | `Security.getMaturityDate()` |
+| `src/routes/+page.server.ts:72` | `issueDate: security.getIssueDate().toDate()` | `Security.getIssueDate()` |
+| `src/routes/+page.server.ts:74` | `maturityDate: security.getMaturityDate().toDate()` | `Security.getMaturityDate()` |
+| `src/routes/treasuries/+page.server.ts:186` | `transactionIssueDate: security.getIssueDate()?.toString() ?? ''` | `Security.getIssueDate()` |
+| `src/routes/treasuries/+page.server.ts:197` | `bondSecurity?.getCouponType().name() ?? ''` | `BondSecurity.getCouponType()` |
+| `src/routes/treasuries/+page.server.ts:199` | `bondSecurity?.getCouponFrequency()?.toString() ?? ''` | `BondSecurity.getCouponFrequency()` |
+| `src/routes/treasuries/+page.server.ts:200` | `transactionMaturityDate: security.getMaturityDate()?.toString() ?? ''` | `Security.getMaturityDate()` |
+
+## Phase-5 PR sequencing
+
+Suggested order — each step is independently mergeable and keeps the suite
+green at every commit (assuming the dual-read shape of the helpers is left in
+place until v0.4.0 actually publishes).
+
+1. **Migrate the two fan-out helpers** (`baseCpiOf`, `couponRateOf`). Read
+   structured-only; delete the flat fallback line. No caller changes; full
+   test suite must stay green. *Can land before v0.4.0 because of optional
+   chaining — see note above.*
+2. **Migrate read sites in `src/lib/transactions.ts`, `src/lib/security.ts`,
+   `src/routes/+page.server.ts`, `src/routes/treasuries/+page.server.ts`,
+   and `src/routes/(authenticated)/data/cpi_index/+page.server.ts`** to the
+   structured oneof getters. *Must wait for v0.4.0 + ledger-service to write
+   structured-shape rows.*
+3. **Migrate `src/lib/valuation.ts` pricer-input builders** (Bond / TIPS /
+   FRN sections). Each pricer's input is consumed by valuation-service —
+   coordinate with `backend-dev-valuation` so the consumer accepts the
+   structured shape before this PR merges (issue #277 sequencing: PR #52
+   redirects to v0.4.0). *Must wait for v0.4.0.*
+
+Step (1) can be a small standalone PR. Steps (2) + (3) should land together
+or behind a feature flag so the dev environment isn't broken between commits.
+
+## Summary
+
+- Total call sites surveyed: **47**
+- RAW_PROTO_READ (must migrate, excluding mis-classified L371-372 settlement chain): **9**
+- WRITE_SIDE (must migrate, all in `valuation.ts`): **14**
+- WRAPPER_READ (no change needed): **24**
+- Fan-out helpers (single migration point cascading): **2**
+
+Files touched by Phase 5:
+- `src/lib/security.ts` (helpers + 2 RAW_PROTO_READ)
+- `src/lib/transactions.ts` (1 RAW_PROTO_READ)
+- `src/lib/valuation.ts` (1 RAW_PROTO_READ + 14 WRITE_SIDE)
+- `src/lib/treasuryCurveData.ts` (via `couponRateOf` helper migration)
+- `src/routes/+page.server.ts` (1 RAW_PROTO_READ)
+- `src/routes/treasuries/+page.server.ts` (1 RAW_PROTO_READ)
+- `src/routes/(authenticated)/data/cpi_index/+page.server.ts` (2 RAW_PROTO_READ)
+
+Test files in `src/tests/**` and `tests/**` move alongside production code in
+the same PRs but are not enumerated here — once a production call site moves,
+its tests are obvious neighbors.


### PR DESCRIPTION
## Summary

Doc-only audit of every ui-service call site that reads or writes the 17 flat
`SecurityProto` fields removed by ledger-models PR #216 (v0.4.0). Output lives
at `docs/v0.4.0-call-site-audit.md`.

For each call site under `src/lib/` and `src/routes/` it records:
- File path and line number
- The current flat access (`getCouponRate`, `setFaceValue`, etc.)
- The structured-oneof replacement (`getBondDetails().getCouponRate()`, etc.)
- One of three categories: WRAPPER_READ (no change needed),
  RAW_PROTO_READ (must migrate), or WRITE_SIDE (must migrate)

Plus a "fan-out helpers" callout — `baseCpiOf` and `couponRateOf` in
`src/lib/security.ts` are single migration points that cover several
downstream call sites.

This sets up the Phase-5 implementation PRs without committing the team to
any code changes today. v0.4.0 (ledger-models #216) is still open and the
ledger-service / market-data-inputs structured rewrites have to land first.

## Numbers

- 47 call sites surveyed
- 9 RAW_PROTO_READ (must migrate)
- 14 WRITE_SIDE (must migrate, all in `valuation.ts`)
- 24 WRAPPER_READ (no caller-side change needed)
- 2 fan-out helpers that consolidate further

## Phase-5 sequencing

Sketched in the doc. Headline: helpers first (can land pre-v0.4.0 due to
optional chaining), then read sites, then `valuation.ts` write sites
(coordinate with `backend-dev-valuation` PR #52 v0.4.0 redirect).

## Tracks

- second-brain#277 — v0.4.0 source issue
- ledger-models#216 — open v0.4.0 PR

## Test plan

- [ ] N/A — doc-only PR. svelte-check / vitest / playwright not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)