### PR TITLE
fix(#268): tolerate curve constituents with no identifier

### DIFF
--- a/src/lib/treasuryCurveData.ts
+++ b/src/lib/treasuryCurveData.ts
@@ -87,9 +87,18 @@ function toCurveConstituent(security: Security, asOf: Date): CurveConstituent {
   try { issueDate = security.getIssueDate()?.toDate() ?? null; } catch { /* non-bond */ }
   try { maturityDate = security.getMaturityDate()?.toDate() ?? null; } catch { /* non-bond */ }
 
-  const cusip = security.getSecurityID()
-    ? security.getSecurityID().getIdentifierValue()
-    : security.getID().toString();
+  // Security.getSecurityID() throws "Identifier is required" when the
+  // underlying proto has no identifier (singular tag 40) and no
+  // identifiers[] (tag 42) populated. The TreasuryCurveResolver currently
+  // returns at least some constituents in that state — see second-brain#268
+  // for the upstream backfill task. Fall back to the bare UUID rather
+  // than blowing up the whole curve render.
+  let cusip: string;
+  try {
+    cusip = security.getSecurityID().getIdentifierValue();
+  } catch {
+    cusip = security.getID().toString();
+  }
 
   const monthsToMaturity = maturityDate ? monthsBetween(asOf, maturityDate) : 0;
   const bucket = bucketForMonths(monthsToMaturity);


### PR DESCRIPTION
## Summary

Defensive fix in `src/lib/treasuryCurveData.ts::toCurveConstituent` so
`/data/curves` and `/data/treasury_curve` don't blow up when the
`TreasuryCurveResolver` returns constituents whose underlying
`SecurityProto` has no identifier (neither singular tag 40 nor `identifiers[]` tag 42).

`Security.getSecurityID()` throws `"Identifier is required"` in that case
(it's been throwing since at least v0.2.5 — the wrapper never returned
falsy here, despite the old call-site treating it as a ternary
condition). The throw propagated out of `toCurveConstituent` →
`loadTreasuryCurveBundle` → page loader and left both pages with the
SSR error `"Failed to resolve Treasury curve constituents: Identifier is required"` and zero data.

Catch the throw and fall back to the bare UUID for the cusip column —
the curve chart only consumes coupon / maturity / clean price, so the
page renders correctly in the degraded mode (CUSIPs display as UUIDs).

## Verification

Live smoke after the fix on this branch (broker rebuilt, ledger-service
direct call confirmed to return 11 constituents):

- **`/data/treasury_curve?asof=2026-05-13`** — HTTP 200, SSR payload
  contains 11 rows (TBILL + TREASURY_NOTE), all priced, tenor/coupon/
  maturity / cleanPrice columns populated. CUSIP column shows UUIDs.
- **`/data/curves?asof=2026-05-13`** — HTTP 200, constituents resolve
  (warning: `"Curve has 8/11 priced constituents."`), but the page
  surfaces a separate downstream error from valuation-service:
  `"RunCurve failed: Curve input security with clean_price requires coupon_rate"`.
  That's a v0.4.0 cutover gap on valuation-service (reads flat
  `SecurityProto.coupon_rate`; ledger now writes
  `BondDetailsProto.coupon_rate`) — outside this PR's scope, filed
  separately on second-brain#268.

## Upstream follow-ups (filed on second-brain#268)

- backend-dev-ledger / data-sourcing-dev — populate `identifiers[]` on
  the Treasury Curve constituent rows so the CUSIP column displays the
  real CUSIP rather than the UUID.
- backend-dev-valuation — migrate `RunCurve` to read coupon rate from
  `BondDetailsProto`, not the deprecated flat `SecurityProto.coupon_rate`.

## Gates

- `npx vitest run src/tests/treasuryCurveData-bucket.test.ts src/tests/treasury-curve-display.test.ts src/tests/curves-server-helpers.test.ts src/tests/curves-page.test.ts` — 65 passed / 10 todo.
- `npx vitest run` (full) — 51/51 files green (with intermittent flake on `prices-universal-identifier-e2e` integration test under broker rate-limit pressure; passed on retry).
- `npx svelte-check` — 79 errors (1 fewer than the baseline on main; no new errors).

## Test plan

- [x] `/data/treasury_curve?asof=2026-05-13` renders 11 constituents with prices.
- [x] `/data/curves?asof=2026-05-13` resolves constituents (downstream RunCurve issue is a separate concern).
- [x] Vitest curve suite passes.
- [ ] (post-merge) Re-smoke after backend-dev-valuation migrates RunCurve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)