### PR TITLE
fix(#292): bump ledger-models to v0.4.4 (closes #292)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@auth/core": "^0.27.0",
 				"@auth/sveltekit": "^0.13.0",
-				"@fintekkers/ledger-models": "^0.4.3",
+				"@fintekkers/ledger-models": "^0.4.4",
 				"@iconify-json/mdi": "^1.2.3",
 				"@iconify-json/ph": "^1.2.2",
 				"@lucia-auth/adapter-drizzle": "^1.0.7",
@@ -2529,9 +2529,9 @@
 			}
 		},
 		"node_modules/@fintekkers/ledger-models": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@fintekkers/ledger-models/-/ledger-models-0.4.3.tgz",
-			"integrity": "sha512-U/A9xIYacarMj+IXwIbXuFydV6j0KUF02FexfaGCuFGzvV8MxSYQ15yCC78Xh93H8KLWW/CEki3Pqjg7F2fdqQ==",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@fintekkers/ledger-models/-/ledger-models-0.4.4.tgz",
+			"integrity": "sha512-ljuDkLbscdUYSgk2/QP/zoWZ/ZkfHKepC28QVaCd3eXB+j1V3q7AHvTKfG9c/SVT3OG4RtJ/Vd4SD3t50JPANQ==",
 			"license": "ISC",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.8.18",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"@auth/core": "^0.27.0",
 		"@auth/sveltekit": "^0.13.0",
-		"@fintekkers/ledger-models": "^0.4.3",
+		"@fintekkers/ledger-models": "^0.4.4",
 		"@iconify-json/mdi": "^1.2.3",
 		"@iconify-json/ph": "^1.2.2",
 		"@lucia-auth/adapter-drizzle": "^1.0.7",


### PR DESCRIPTION
Closes second-brain#292.

## Summary
ledger-models PR #220 regenerated the JS bindings against a v4-aware `protoc`, replacing the 3.x-only `reader.readPackedEnum()` calls with the v4 `readPackableEnumInto(arr)` shim. v0.4.4 ships that regen. This PR bumps the consumer.

The earlier consumer-side workaround (PR #173 — pin `google-protobuf` back to `^3.21.4` via `overrides`) was correctly rejected: it would have carried the v3 pin forward to every future consumer of `@fintekkers/ledger-models`. Fix is now upstream; consumer just needs the version bump.

## Changes
- `package.json`: `@fintekkers/ledger-models` `^0.4.3` → `^0.4.4`.
- `package-lock.json`: regenerated.
- **No `overrides` block. No `google-protobuf` pin.** The runtime stays on the regen-contract version (`^4.0.2`).

## Verification

### Mechanical proof of the fix
```
$ npm ls google-protobuf
fin-ui@0.0.1
├─┬ @fintekkers/ledger-models@0.4.4
│ └── google-protobuf@4.0.2 deduped
└── google-protobuf@4.0.2
```
Single resolution at `4.0.2` across the entire tree.

```
$ grep -l "readPackedEnum" node_modules/@fintekkers/ledger-models/node/**/*_pb.js
(no output)
$ grep -l "readPackableEnumInto" node_modules/@fintekkers/ledger-models/node/**/*_pb.js
…/get_fields_response_pb.js
…/query_position_request_pb.js
…/valuation_request_pb.js
…/curve_request_pb.js
```
All four formerly-broken `_pb.js` files now use the v4 API; zero `readPackedEnum` calls remain in production output (only in ledger-models's own regression test file, as a sentinel).

### Round-trip the original failing shape
```js
// DIRECTED_QUANTITY alone — exact #292 repro
const r = new QueryPositionRequestProto();
r.setMeasuresList([MeasureProto.DIRECTED_QUANTITY]);
QueryPositionRequestProto.deserializeBinary(r.serializeBinary());
// → DIRECTED_QUANTITY-only round-trip: [ 1 ] OK

// Multi packed-enum (fields + measures)
// → Multi packed-enum round-trip — fields: 2 measures: 2 OK

console.log(typeof BinaryReader.prototype.readPackedEnum);     // undefined  ✔ (v4 removed it)
console.log(typeof BinaryReader.prototype.readPackableEnumInto); // function  ✔ (v4 replacement)
```

### Gates
- **vitest** (`npm test`): 459 passed | 0 failed | 10 todo.
- **vitest:integration** (`npm run test:integration` per #288 split): 159 passed | 0 failed across 2 consecutive runs (one transient flake on the first run did not reproduce on the next two).
- **svelte-check**: 105 errors (matches main baseline; no new TS issues).
- **playwright** (positions / curves spec subset): 4 passed. 2 failures (`curves-latest-buildable-date.spec.ts:43`, `treasury-curve-strips-filter.spec.ts:30`) reproduced on main with v0.4.3 — pre-existing baseline, unrelated to this bump.

## Test plan
- [x] `npm ls google-protobuf` shows single resolution at 4.0.2
- [x] All `_pb.js` files use `readPackableEnumInto`; none call `readPackedEnum`
- [x] `QueryPositionRequest` round-trip with `DIRECTED_QUANTITY` alone (the exact #292 repro)
- [x] vitest unit + integration green
- [x] svelte-check no new errors
- [x] No `overrides` block, no consumer-side `google-protobuf` pin
- [ ] Manual: log into the UI, open `/data/positions` for a real portfolio, confirm the grid renders without `readPackedEnum` error (flagging for PM verification — needs an authenticated session)