### PR TITLE
fix(#301 slice A): lift Dec-2025 date cap on /treasuries2

### DIFF
--- a/src/routes/treasuries2/+page.server.ts
+++ b/src/routes/treasuries2/+page.server.ts
@@ -5,8 +5,15 @@ export async function load({ locals }) {
   // Thread apiKey through so the underlying PositionService.search goes via
   // the broker's authenticated route. Without it the call fails with
   // `16 UNAUTHENTICATED: API key required`. Same fix as 5d8f052 for /treasuries3.
+  // #301 slice A (split from the larger MBS-overlay PR per PM): the
+  // hardcoded asOf was a debugging anchor that left every transaction
+  // past 2026-01-01 invisible — including the 2,366 SOMA Agency MBS
+  // BUYs loaded today via #274. `new Date()` reloads the full SOMA
+  // history through today; downstream graphs already accept arbitrary
+  // date ranges. Larger overlay + tie-out work continues on
+  // feature/301-treasuries2-mbs-overlay.
   const transactions = await getTreasuryTransactions(
-    new Date('2026-01-01T00:59:59'),
+    new Date(),
     locals.user?.apiKey,
   );
 


### PR DESCRIPTION
Refs second-brain#301. Slice A of the larger MBS-overlay feature, **split out per PM so MBS becomes visible today**. Overlay traces / current-month shading / Fed H.4.1 tie-out continue on `feature/301-treasuries2-mbs-overlay`.

## Symptom
`/treasuries2` was hardcoded to `asOf = new Date('2026-01-01T00:59:59')`, filtering out every transaction past 2026-01-01 — including the 2,366 SOMA Agency MBS BUYs loaded today via #274. Users saw a Treasury-only view with no Agency MBS series at all.

## Fix
One-line change in `src/routes/treasuries2/+page.server.ts:9`:
```diff
- new Date('2026-01-01T00:59:59'),
+ new Date(),
```
Downstream graphs already accept arbitrary date ranges — no other changes needed for the cap lift in isolation.

## Manual smoke (post-restart on local dev)
- `GET /treasuries2` → 200, payload size **6.55 MB** (was ~1.5 MB pre-fix).
- Distinct `PRODUCT_TYPE` values in payload: **MORTGAGE_BACKED**, TBILL, TIPS, TREASURY_BOND, TREASURY_FRN, TREASURY_NOTE — MBS now flowing through.
- Latest `TRADE_DATE` in payload: `1778803200000` ms = **2026-05-15** (today, vs 2025-12-31 max pre-fix).
- No errors / no `toDate` / no `TypeError` in ui-service log post-restart.

## Gates (all unchanged from main baseline)
- **svelte-check**: 83 errors / 205 warnings.
- **vitest unit**: 408 / 0 fail.
- **vitest:integration**: 210 / 0 fail.

## What's NOT in this PR (still on `feature/301-treasuries2-mbs-overlay`)
- MBS overlay as a distinct trace per graph (PM-required visual contract).
- Current-month "in progress — partial month" striped shading.
- Fed H.4.1 tie-out panel + yellow-state threshold rule.
- Playwright regression that asserts both Treasury + MBS traces render and current-month pattern is visible.

Those slices are ~4× bigger and depend on `market-data-inputs` shipping the H.4.1 fetch (tracked separately on #301). This PR is the cap-lift only so the MBS-data-loaded-but-not-shown bug is resolved today; the larger overlay PR follows once the dependency is ready.

## Test plan
- [x] Cap lifted; payload includes MBS + 2026 transactions
- [x] svelte-check, vitest unit, vitest:integration green (unchanged from baseline)
- [ ] PM browser-smoke: log into the UI, open `/treasuries2`, confirm transactions through today are visible (MBS will still be merged into Treasury bars on the existing graphs — distinct overlay comes in the larger PR)