### PR TITLE
fix(#305 part B): /data/treasury_curve plots par yields, not coupon rate

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,54 @@
+name: playwright
+
+# Per-page render smokes (per-loader smoke equivalent for the UI; see
+# processes/test-discipline.md, second-brain#297 + #311).
+#
+# Trigger is workflow_dispatch ONLY today. The specs in tests/e2e/ all
+# depend on the `auth.setup.ts` setup project, which writes
+# playwright/.auth/user.json after authenticating against a real broker
+# on 127.0.0.1:80. CI does not yet provision the gRPC stack
+# (postgres + 4 services + ui dev server), so the setup project skips
+# itself when the broker is unreachable, the storageState file is never
+# written, and every dependent spec fails with ENOENT — 63 noise
+# failures, no real signal.
+#
+# Wiring on `pull_request` is one PR away once CI gets the stack:
+# uncomment the pull_request + push triggers below. Until then, run on
+# demand via the Actions tab → "playwright" → "Run workflow", or
+# locally against the running services.sh stack.
+#
+# Manual run prerequisites: same as local — broker on :80, ui-service
+# on :443, ledger-service on :8082, valuation-service on :8080. Without
+# them, expect the same ENOENT cascade as the original wiring attempt.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: e2e per-page render smokes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright browsers (chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: svelte-kit sync
+        run: npx svelte-kit sync
+
+      - name: playwright test
+        run: npx playwright test --reporter=github

--- a/src/lib/runCurve.ts
+++ b/src/lib/runCurve.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared RunCurve plumbing — extracted from /data/curves/+page.server.ts
+ * so /data/treasury_curve can plot real par yields per tenor instead of
+ * the bond's coupon rate (#305 part B).
+ *
+ * Same wire shape as the live-curves page: build a CurveRequestProto
+ * carrying the constituent SecurityProtos + clean prices, ask the
+ * valuation service for PAR_YIELD (and SPOT/FORWARD if the caller
+ * wants), and return par-yields keyed by the constituent's tenor label
+ * so per-row joins on `tenor` work.
+ */
+import { ValuationClient } from '@fintekkers/ledger-models/node/fintekkers/services/valuation-service/valuation_service_grpc_pb.js';
+import { CurveRequestProto, CurveInputProto } from '@fintekkers/ledger-models/node/fintekkers/requests/valuation/curve_request_pb.js';
+import type { CurveResponseProto } from '@fintekkers/ledger-models/node/fintekkers/requests/valuation/curve_response_pb.js';
+import { DecimalValueProto } from '@fintekkers/ledger-models/node/fintekkers/models/util/decimal_value_pb.js';
+import measure_pkg from '@fintekkers/ledger-models/node/fintekkers/models/position/measure_pb.js';
+import { ZonedDateTime } from '@fintekkers/ledger-models/node/wrappers/models/utils/datetime';
+import { getServiceConnection } from '$lib/grpc-auth';
+import type { CurveConstituent } from '$lib/treasuryCurveData';
+
+const { MeasureProto } = measure_pkg;
+
+function decimal(value: string): DecimalValueProto {
+  return new DecimalValueProto().setArbitraryPrecisionValue(value);
+}
+
+function endOfDayProto(asOf: Date) {
+  const eod = new Date(Date.UTC(
+    asOf.getUTCFullYear(), asOf.getUTCMonth(), asOf.getUTCDate(),
+    23, 59, 59, 999,
+  ));
+  return ZonedDateTime.from(eod).toProto();
+}
+
+/**
+ * Build the par-yields-only CurveRequest. /data/treasury_curve doesn't
+ * need spot/forward — the per-row table just needs PAR_YIELD per
+ * tenor. Skipping spot/forward keeps the response small and the
+ * client→server payload tighter.
+ */
+function buildParYieldRequest(constituents: CurveConstituent[], asOf: Date): CurveRequestProto {
+  const request = new CurveRequestProto();
+  request.setObjectClass('CurveRequestProto');
+  request.setVersion('0.0.1');
+  request.setAsofDatetime(endOfDayProto(asOf));
+  request.setCurveTypesList([MeasureProto.PAR_YIELD]);
+  for (const c of constituents) {
+    if (c.cleanPrice === null) continue;
+    const input = new CurveInputProto();
+    input.setSecurity((c.bond as any).proto);
+    input.setCleanPrice(decimal(c.cleanPrice.toString()));
+    request.addCurveInputs(input);
+  }
+  return request;
+}
+
+/**
+ * Map RunCurve par-yield points back to the input constituents by
+ * matching on years-to-maturity (the wire response carries `tenor` in
+ * decimal years; constituents carry a `bucketMonths` we convert the
+ * same way). We round both sides to two decimals so float-precision
+ * artefacts don't cause spurious misses.
+ */
+function joinByTenor(
+  constituents: CurveConstituent[],
+  parPoints: Array<{ years: number; yieldPct: number }>,
+): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const c of constituents) {
+    const cMonths = c.bucketMonths;
+    const cYears = cMonths / 12;
+    // Find the closest point within 0.05 years (~ 18 days). The
+    // resolver's bucket labels (1M, 3M, 6M, 1Y, 2Y, 3Y, 5Y, 7Y, 10Y,
+    // 20Y, 30Y) are coarse enough that the closest point is unambiguous.
+    let best: { years: number; yieldPct: number } | null = null;
+    let bestDelta = Number.POSITIVE_INFINITY;
+    for (const p of parPoints) {
+      const d = Math.abs(p.years - cYears);
+      if (d < bestDelta) { bestDelta = d; best = p; }
+    }
+    if (best && bestDelta <= 0.05) out.set(c.tenor, best.yieldPct);
+  }
+  return out;
+}
+
+/**
+ * Compute par-yield-per-tenor for the given constituents at the given
+ * asOf. Returns an empty map if RunCurve fails or if fewer than 2
+ * constituents have prices (curve fitter needs ≥2 to bootstrap).
+ *
+ * Caller is responsible for deciding what to do with missing tenors;
+ * the /data/treasury_curve page renders `—` in the column for any
+ * row whose tenor isn't in the map.
+ */
+export async function runCurveParYieldsByTenor(
+  constituents: CurveConstituent[],
+  asOf: Date,
+  apiKey?: string,
+): Promise<Map<string, number>> {
+  const priced = constituents.filter((c) => c.cleanPrice !== null);
+  if (priced.length < 2) return new Map();
+
+  const request = buildParYieldRequest(priced, asOf);
+  if (request.getCurveInputsList().length < 2) return new Map();
+
+  let response: CurveResponseProto;
+  try {
+    const conn = getServiceConnection(apiKey);
+    const client = new ValuationClient(conn.url, conn.credentials, { interceptors: conn.interceptors });
+    response = await new Promise<CurveResponseProto>((resolve, reject) => {
+      client.runCurve(request, (err, resp) => (err ? reject(err) : resolve(resp)));
+    });
+  } catch (e: any) {
+    console.warn(`runCurveParYieldsByTenor — RunCurve failed: ${e?.details ?? e?.message ?? e}`);
+    return new Map();
+  }
+
+  const parPoints: Array<{ years: number; yieldPct: number }> = [];
+  for (const result of response.getCurveResultsList()) {
+    if (result.getCurveType() !== MeasureProto.PAR_YIELD) continue;
+    for (const point of result.getPointsList()) {
+      const tenorStr = point.getTenor()?.getArbitraryPrecisionValue();
+      const yieldStr = point.getYield()?.getArbitraryPrecisionValue();
+      if (!tenorStr || !yieldStr) continue;
+      const years = parseFloat(tenorStr);
+      const yieldPct = parseFloat(yieldStr) * 100;
+      if (Number.isFinite(years) && Number.isFinite(yieldPct)) {
+        parPoints.push({ years, yieldPct });
+      }
+    }
+  }
+
+  return joinByTenor(constituents, parPoints);
+}

--- a/src/routes/(authenticated)/data/treasury_curve/+page.server.ts
+++ b/src/routes/(authenticated)/data/treasury_curve/+page.server.ts
@@ -17,6 +17,7 @@ import {
   loadTreasuryCurveBundle,
   type ConstituentBundle,
 } from '$lib/treasuryCurveData';
+import { runCurveParYieldsByTenor } from '$lib/runCurve';
 
 const LATEST_DATE_SCAN_DAYS = 30;
 
@@ -28,6 +29,10 @@ export interface TreasuryCurveRow {
   maturityDate: string;
   couponRate: number;
   cleanPrice: number | null;  // null = no price found at/before as-of
+  // #305 part B: par yield from RunCurve, joined by tenor. null when
+  // RunCurve had insufficient inputs (≪2 priced constituents) or the
+  // valuation service errored — chart + column degrade to '—'.
+  parYield: number | null;
 }
 
 interface PageData {
@@ -37,7 +42,7 @@ interface PageData {
   asofWasDefaulted: boolean;
 }
 
-function bundleToRows(bundle: ConstituentBundle): TreasuryCurveRow[] {
+function bundleToRows(bundle: ConstituentBundle, parYieldsByTenor: Map<string, number>): TreasuryCurveRow[] {
   return bundle.constituents.map((c) => {
     const maturity = c.maturityDate ? c.maturityDate.toISOString().slice(0, 10) : '';
     const issue = c.issueDate ? c.issueDate.toISOString().slice(0, 10) : '';
@@ -52,6 +57,7 @@ function bundleToRows(bundle: ConstituentBundle): TreasuryCurveRow[] {
       maturityDate: maturity,
       couponRate: c.couponRate,
       cleanPrice: c.cleanPrice,
+      parYield: parYieldsByTenor.get(c.tenor) ?? null,
     };
   });
 }
@@ -95,8 +101,20 @@ export async function load({ url, locals }: { url: URL; locals: App.Locals }): P
 
   const selectedDate = asOfDate.toISOString().slice(0, 10);
 
+  // #305 part B: fit a par-yield curve via RunCurve from the priced
+  // constituents and join back per-tenor so the page can plot real
+  // yields instead of bond coupon rates. Failure mode is non-fatal —
+  // an empty map degrades the chart Y axis to '—' for every row, but
+  // the table + price column still render.
+  let parYieldsByTenor = new Map<string, number>();
+  try {
+    parYieldsByTenor = await runCurveParYieldsByTenor(bundle.constituents, asOfDate, apiKey);
+  } catch (e: any) {
+    console.warn('runCurveParYieldsByTenor threw:', e?.message ?? e);
+  }
+
   return {
-    curveData: bundleToRows(bundle),
+    curveData: bundleToRows(bundle, parYieldsByTenor),
     selectedDate,
     latestBuildableDate: latestBuildableDateStr,
     asofWasDefaulted,

--- a/src/routes/(authenticated)/data/treasury_curve/+page.svelte
+++ b/src/routes/(authenticated)/data/treasury_curve/+page.svelte
@@ -5,6 +5,8 @@
     tenor: string; cusip: string; description: string;
     issueDate: string; maturityDate: string; couponRate: number;
     cleanPrice: number | null;
+    // #305 part B: par yield from RunCurve, joined by tenor.
+    parYield: number | null;
   }>; selectedDate: string; latestBuildableDate: string | null;
     asofWasDefaulted: boolean; user?: any };
 
@@ -30,14 +32,20 @@
   onMount(async () => {
     if (!chartEl || curveData.length === 0) return;
     const Plotly: any = (await import('plotly.js-dist') as any).default ?? (await import('plotly.js-dist'));
+    // #305 part B: plot real par yields from RunCurve, not the bond
+    // coupon rate (which is fixed at issuance and diverges from yield
+    // when bonds trade away from par). Skip rows whose parYield is
+    // null — typically Bills and any constituent that the fitter
+    // couldn't price (insufficient curve inputs).
+    const plotted = curveData.filter((d) => d.parYield !== null);
     const trace = {
-      x: curveData.map((d) => d.tenor),
-      y: curveData.map((d) => d.couponRate),
+      x: plotted.map((d) => d.tenor),
+      y: plotted.map((d) => d.parYield as number),
       mode: 'lines+markers',
       line: { color: '#7cd2ba', width: 2.5, shape: 'linear' },
       marker: { color: '#7cd2ba', size: 8 },
       hovertemplate: '%{x}: %{y:.3f}%<extra></extra>',
-      name: 'On-the-run',
+      name: 'Par yield',
     };
     const layout = {
       paper_bgcolor: '#0c3a46',
@@ -99,6 +107,7 @@
           <th>Issue Date</th>
           <th>Maturity Date</th>
           <th>Coupon Rate (%)</th>
+          <th>Par Yield (%)</th>
           <th>Clean Price</th>
         </tr>
       </thead>
@@ -115,6 +124,7 @@
             <td>{point.issueDate || '—'}</td>
             <td>{point.maturityDate || '—'}</td>
             <td class="yield-cell">{point.couponRate.toFixed(3)}%</td>
+            <td class="par-yield-cell">{point.parYield !== null && point.parYield !== undefined ? `${point.parYield.toFixed(3)}%` : '—'}</td>
             <td class="price-cell">{point.cleanPrice !== null && point.cleanPrice !== undefined ? point.cleanPrice.toFixed(4) : '—'}</td>
           </tr>
         {/each}

--- a/tests/e2e/curves-pages-render.spec.ts
+++ b/tests/e2e/curves-pages-render.spec.ts
@@ -20,7 +20,12 @@
 import { test, expect } from '@playwright/test';
 
 const CURVES_URL = '/data/curves?asof=2026-05-15&term=10';
+// 2026-04-08 used for the row-count + non-Bill-coupon assertions (#302
+// repro lived on a stale historical day). #305 part B/C use a recent
+// date because RunCurve needs priced constituents and prices in the
+// running ledger only exist on the most recent days.
 const TREASURY_CURVE_URL = '/data/treasury_curve?date=2026-04-08';
+const TREASURY_CURVE_RECENT_URL = '/data/treasury_curve?date=2026-05-15';
 
 // EXPECTED_CONSTITUENT_COUNT in $lib/treasuryCurveData = 11
 // (TENOR_BUCKETS spans {1M, 3M, 6M, 1Y, 2Y, 3Y, 5Y, 7Y, 10Y, 20Y, 30Y}).
@@ -132,6 +137,70 @@ test.describe('/data/curves + /data/treasury_curve render real data (#302)', () 
     expect(
       offenders,
       `non-Bill tenors with zero/missing coupon (would have masked #302): ${JSON.stringify(offenders)}`,
+    ).toEqual([]);
+  });
+
+  // #305 part B: chart used to plot couponRate as the Y axis (Bills
+  // came out at 0%, notes flat-lined at their fixed coupons regardless
+  // of where they traded). Post-fix the page-server runs RunCurve and
+  // joins par yields per tenor; the chart Y series is parYield, NOT
+  // couponRate. This assertion locks that contract by reading the
+  // page payload's serialized parYield array and checking it differs
+  // from couponRate on at least one row.
+  test('/data/treasury_curve part B: par yields rendered (Y axis ≠ couponRate column)', async ({ page }) => {
+    const response = await page.goto(TREASURY_CURVE_RECENT_URL);
+    expect(response!.status()).toBeLessThan(500);
+
+    // Read the rendered table cells: column 5 = Coupon Rate (yield-cell),
+    // column 6 = Par Yield (par-yield-cell). Pre-#305-part-B the page
+    // didn't have a Par Yield column at all and the chart Y was driven
+    // off the coupon column; the contract this test locks is that the
+    // par-yield column exists, has at least one numeric value, and
+    // disagrees with the coupon column on at least one row (Bills:
+    // coupon=0%, par=~3-4%; off-par notes: coupon != par).
+    const rows = page.locator('table tbody tr');
+    await expect.poll(async () => rows.count(), { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(EXPECTED_CONSTITUENT_COUNT_MIN);
+
+    const rowCount = await rows.count();
+    let anyParYieldRendered = false;
+    let rowsWhereYieldDiffersFromCoupon = 0;
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i);
+      const couponText = (await row.locator('td.yield-cell').innerText()).trim();
+      const parText = (await row.locator('td.par-yield-cell').innerText()).trim();
+      if (parText === '—') continue;
+      anyParYieldRendered = true;
+      const coupon = parseFloat(couponText.replace('%', ''));
+      const par = parseFloat(parText.replace('%', ''));
+      if (Number.isFinite(coupon) && Number.isFinite(par) && Math.abs(coupon - par) > 0.01) {
+        rowsWhereYieldDiffersFromCoupon++;
+      }
+    }
+    expect(
+      anyParYieldRendered,
+      'no row had a non-null Par Yield — RunCurve returned no usable curve, par-yield column hard-coded to "—"',
+    ).toBe(true);
+    expect(
+      rowsWhereYieldDiffersFromCoupon,
+      'every priced row had parYield equal to couponRate — chart probably still plots coupon (#305 part B regression)',
+    ).toBeGreaterThan(0);
+  });
+
+  // #305 part C: POSTCUT01 (uuid dbd72c65-…) was a stray test fixture
+  // that surfaced in an earlier on-the-run constituent. data-sourcing-dev
+  // owns the ledger cleanup; the UI-side assertion guards against any
+  // POST*/TEST* identifier ever resurfacing in the curve picker.
+  test('/data/treasury_curve part C: no POST*/TEST* identifiers in any row', async ({ page }) => {
+    const response = await page.goto(TREASURY_CURVE_RECENT_URL);
+    expect(response!.status()).toBeLessThan(500);
+
+    const html = await page.content();
+    const cusips = [...html.matchAll(/cusip:"([^"]+)"/g)].map((m) => m[1]);
+    const offenders = cusips.filter((id) => /^(POST|TEST)/i.test(id));
+    expect(
+      offenders,
+      `stray test/POSTCUT identifiers leaked into the curve picker: ${JSON.stringify(offenders)}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Refs second-brain#305. Part B of three (A: PriceService blank prices — data-side, documented; B: chart Y axis here; C: POSTCUT01 Playwright guardrail also added below).

## Pre-fix
The chart at `+page.svelte:35` plotted `d.couponRate` as the Y axis. Bills (zero-coupon by definition) flat-lined at 0% and notes flat-lined at their fixed coupons regardless of where they actually traded — a financial-correctness bug for anyone reading the page as a yield curve.

## Fix
Extract the `/data/curves` RunCurve plumbing into a small `$lib/runCurve.ts` helper (`runCurveParYieldsByTenor`) and call it from `/data/treasury_curve`'s page-server. Returns a `Map<tenor, parYieldPct>` joined back per row. Failure modes (<2 priced constituents, RunCurve service error) degrade to an empty map — chart skips those rows, table renders `—`.

## UI surface
- New `Par Yield (%)` column on the table (between Coupon Rate and Clean Price).
- Chart Y series swapped from `d.couponRate` to `d.parYield`. Trace renamed `On-the-run` → `Par yield`.

## Verification (manual smoke on 2026-05-15)
| Tenor | Coupon | Clean Price | Par Yield |
|-------|--------|-------------|-----------|
| 3M    | 0%     | 98.84       | **3.700%** |
| 6M    | 0%     | 98.18       | **3.763%** |
| 1Y    | 0%     | 96.33       | **3.832%** |
| 2Y    | 3.75%  | 99.53       | **3.996%** |
| 7Y    | 4.125% | 99.00       | **4.292%** |

Bills now show real ~3.7% yields where pre-fix they showed 0%; off-par notes show market par yield.

## Regression test additions
`tests/e2e/curves-pages-render.spec.ts`:
- **Part B**: walks the rendered table, asserts ≥1 row has a non-null Par Yield AND ≥1 row's Par Yield differs from its Coupon Rate by >0.01%.
- **Part C**: walks all rendered cusip values, asserts none start with `POST` or `TEST` (POSTCUT01 guardrail).

## Out of scope
**Part A — Clean Price column blank**: diagnosed via direct grpc probes — running ledger has only ~1 price record per treasury constituent (dated 2026-05-14). UI lookup path is mechanically correct. When `asOf` < the only known price date, the column legitimately shows `—`. Real fix is data-side: backfill historical treasury prices.

## Branch note
Includes commit `1bdb98c` (`ci(#311): playwright workflow_dispatch only`) added by another agent on this branch — outside this PR's scope but ride-along.

## Gates
- **svelte-check**: 83 errors (unchanged baseline).
- **vitest unit**: 408 / 0 fail.
- **vitest:integration**: 210 / 0 fail.
- **playwright** (`curves-pages-render.spec.ts`): 5 / 5 pass.