### PR TITLE
fix(#315): join treasury_curve par-yields by actual maturity-years (cherry-pick of 48e222c)

### DIFF
--- a/src/lib/runCurve.ts
+++ b/src/lib/runCurve.ts
@@ -56,29 +56,43 @@ function buildParYieldRequest(constituents: CurveConstituent[], asOf: Date): Cur
 
 /**
  * Map RunCurve par-yield points back to the input constituents by
- * matching on years-to-maturity (the wire response carries `tenor` in
- * decimal years; constituents carry a `bucketMonths` we convert the
- * same way). We round both sides to two decimals so float-precision
- * artefacts don't cause spurious misses.
+ * matching on years-to-maturity. The fitter emits at each bond's
+ * ACTUAL years-to-maturity (e.g. 0.2055 for a 1M bill that's 75 days
+ * out, 29.76 for a 30Y bond auctioned ~3 months ago), NOT at the
+ * canonical bucket year (1/12, 30, …). Joining by `bucketMonths/12`
+ * with a tight window left 4 of 9 priced constituents unmapped on
+ * 2026-05-14 (#305 reopen): 1M (delta 0.12), 3Y (0.08), 20Y (0.24),
+ * 30Y (0.24).
+ *
+ * Fix: compute each constituent's maturityYears from the actual
+ * maturityDate field and asOf, then pair to the closest fitter point.
+ * Tolerance widened to 0.5y — well under the smallest inter-bucket
+ * gap (1Y → 2Y, 6M → 1Y) so cross-matching adjacent buckets stays
+ * impossible, but loose enough to absorb day-count / end-of-day
+ * conventions on either side.
  */
-function joinByTenor(
+function joinByMaturityYears(
   constituents: CurveConstituent[],
   parPoints: Array<{ years: number; yieldPct: number }>,
+  asOf: Date,
 ): Map<string, number> {
   const out = new Map<string, number>();
+  const MS_PER_YEAR = 365.25 * 86400 * 1000;
   for (const c of constituents) {
-    const cMonths = c.bucketMonths;
-    const cYears = cMonths / 12;
-    // Find the closest point within 0.05 years (~ 18 days). The
-    // resolver's bucket labels (1M, 3M, 6M, 1Y, 2Y, 3Y, 5Y, 7Y, 10Y,
-    // 20Y, 30Y) are coarse enough that the closest point is unambiguous.
+    if (!c.maturityDate) continue;
+    const cYears = (c.maturityDate.getTime() - asOf.getTime()) / MS_PER_YEAR;
+    if (!Number.isFinite(cYears) || cYears <= 0) continue;
     let best: { years: number; yieldPct: number } | null = null;
     let bestDelta = Number.POSITIVE_INFINITY;
     for (const p of parPoints) {
       const d = Math.abs(p.years - cYears);
       if (d < bestDelta) { bestDelta = d; best = p; }
     }
-    if (best && bestDelta <= 0.05) out.set(c.tenor, best.yieldPct);
+    // 0.5y tolerance: smallest inter-bucket gap is 0.5y (6M → 1Y)
+    // so cross-matching adjacent buckets is impossible. Day-count /
+    // end-of-day conventions account for ~0.01y; a real fitter
+    // mismatch would be ≫ 0.5y.
+    if (best && bestDelta <= 0.5) out.set(c.tenor, best.yieldPct);
   }
   return out;
 }
@@ -130,5 +144,5 @@ export async function runCurveParYieldsByTenor(
     }
   }
 
-  return joinByTenor(constituents, parPoints);
+  return joinByMaturityYears(constituents, parPoints, asOf);
 }

--- a/tests/e2e/curves-pages-render.spec.ts
+++ b/tests/e2e/curves-pages-render.spec.ts
@@ -165,11 +165,27 @@ test.describe('/data/curves + /data/treasury_curve render real data (#302)', () 
     const rowCount = await rows.count();
     let anyParYieldRendered = false;
     let rowsWhereYieldDiffersFromCoupon = 0;
+    const pricedWithoutYield: { tenor: string; price: string }[] = [];
     for (let i = 0; i < rowCount; i++) {
       const row = rows.nth(i);
+      const tenor = (await row.locator('td').nth(0).innerText()).trim();
       const couponText = (await row.locator('td.yield-cell').innerText()).trim();
       const parText = (await row.locator('td.par-yield-cell').innerText()).trim();
+      const priceText = (await row.locator('td.price-cell').innerText()).trim();
+
+      // Coverage check — locks the #305-reopen gap fix. Pre-fix the
+      // join used canonical bucket years (1M=0.083, 30Y=30.0) but the
+      // fitter emits at the bond's actual maturity-derived years
+      // (1M Bill=0.21, 30Y Bond=29.76). Bonds whose actual maturity
+      // was >0.05y from the bucket label silently lost their parYield
+      // (1M, 3Y, 20Y, 30Y on 2026-05-14). Any priced row MUST now
+      // come back with a par yield — flag offenders loudly.
+      if (priceText !== '—' && parText === '—') {
+        pricedWithoutYield.push({ tenor, price: priceText });
+        continue;
+      }
       if (parText === '—') continue;
+
       anyParYieldRendered = true;
       const coupon = parseFloat(couponText.replace('%', ''));
       const par = parseFloat(parText.replace('%', ''));
@@ -185,6 +201,10 @@ test.describe('/data/curves + /data/treasury_curve render real data (#302)', () 
       rowsWhereYieldDiffersFromCoupon,
       'every priced row had parYield equal to couponRate — chart probably still plots coupon (#305 part B regression)',
     ).toBeGreaterThan(0);
+    expect(
+      pricedWithoutYield,
+      `priced constituents missing a par yield (#305-reopen gap regression): ${JSON.stringify(pricedWithoutYield)}`,
+    ).toEqual([]);
   });
 
   // #305 part C: POSTCUT01 (uuid dbd72c65-…) was a stray test fixture


### PR DESCRIPTION
## Summary

Cherry-picks `48e222c` ("fix(#305 reopen): join par yields by maturity-years, not bucket-years") from the unmerged `feature/305-treasury-curve-prices-yields-postcut` branch onto a fresh #315 branch. The fix had been written, verified, and gated locally during the #305 reopen, but PR #182 merged before the follow-up commit was added — leaving the bug on `main`.

Closes second-brain#315.

## What's broken on `main`

`src/lib/runCurve.ts:64-84` joins each curve constituent's **canonical bucket year** (`bucketMonths/12` → 1M=0.083, 3M=0.25, …, 30Y=30.0) against the fitter's emitted points, with a tight **0.05y (~18 day) tolerance**.

The fitter emits at each bond's **actual** years-to-maturity, not the canonical bucket. On `/data/treasury_curve?date=2026-05-14` (post-#314 — real CUSIPs in every slot), the join silently drops every constituent whose actual maturity is more than 0.05y from its bucket label:

| Tenor | CUSIP       | Maturity     | actual yrs | bucket yrs | δ (min) | matched? | matched what |
|------:|-------------|--------------|-----------:|-----------:|--------:|:--------:|--------------|
| 1M    | `912797UR6` | 2026-07-28   | 0.205      | 0.083      | 0.122   | **NO**   | — |
| 3M    | `912797VB0` | 2026-09-08   | 0.320      | 0.250      | 0.045†  | yes (cross-match) | **0.205 — 1M's bond** |
| 6M    | `912797UY1` | 2026-11-12   | 0.499      | 0.500      | 0.001   | yes      | 6M's bond (correct) |
| 1Y    | `912797UX3` | 2027-05-13   | 0.999      | 1.000      | 0.001   | yes      | 1Y's bond (correct) |
| 2Y    | `91282CQL8` | 2028-04-30   | 1.964      | 2.000      | 0.036   | yes      | 2Y's bond (correct) |
| 3Y    | `91282CQJ3` | 2029-04-15   | 2.920      | 3.000      | 0.080   | **NO**   | — |
| 5Y    | `91282CQK0` | 2031-04-30   | 4.961      | 5.000      | 0.039   | yes      | 5Y's bond (correct) |
| 7Y    | `91282CQN4` | 2033-04-30   | 6.961      | 7.000      | 0.039   | yes      | 7Y's bond (correct) |
| 10Y   | `91282CPZ8` | 2036-02-15   | 9.759      | 10.000     | 0.241   | **NO**   | — |
| 20Y   | `912810UT3` | 2046-02-15   | 19.760     | 20.000     | 0.240   | **NO**   | — |
| 30Y   | `912810UR7` | 2056-02-15   | 29.760     | 30.000     | 0.240   | **NO**   | — |

† 3M's "match" is **silently incorrect**: with `bucketYears=0.25` the closest fitter point in the all-of-them set is the 1M bond's 0.205 (δ=0.045, just inside the 0.05 window), so the displayed 3M par yield is actually the 1M bond's yield. The row shows a number so the user can't tell from the table — but it's wrong-value, not missing-value. This PR fixes that too.

So 6 of 11 rows "match" on `main`, but only 5 are correct; 5 of 11 drop entirely. Matches the user's reported pattern exactly: missing 1M, 3Y, 10Y, 20Y, 30Y; "working" 3M (wrong yield) + 6M, 1Y, 2Y, 5Y, 7Y (correct yields).

### Case-(a) framing (per #315 dispatch)

The dispatch asked whether the 5 missing rows were case (a) — fitter emits values but UI join drops them — or case (b) — fitter doesn't emit at those points. My hand-computed actual-maturity-years above predict the fitter emits at 0.205 / 0.320 / 0.499 / 0.999 / 1.964 / 2.920 / 4.961 / 6.961 / 9.759 / 19.760 / 29.760. **backend-dev-valuation's parallel probe is the cross-check.** If their (3) probe disagrees with these numbers, my diagnosis flips to (b) and this PR should hold. Will link their comment here as soon as it lands.

## The fix

```diff
-function joinByTenor(constituents, parPoints) {
+function joinByMaturityYears(constituents, parPoints, asOf) {
   for (const c of constituents) {
-    const cYears = c.bucketMonths / 12;            // canonical (1M=0.083, …)
+    if (!c.maturityDate) continue;
+    const cYears = (c.maturityDate.getTime() - asOf.getTime()) / MS_PER_YEAR;
+    if (!Number.isFinite(cYears) || cYears <= 0) continue;
     // closest fitter point …
-    if (best && bestDelta <= 0.05) out.set(c.tenor, best.yieldPct);
+    if (best && bestDelta <= 0.5)  out.set(c.tenor, best.yieldPct);
   }
 }
```

1. **Join by actual maturityYears (`maturityDate − asOf`)**, not canonical bucket years. Removes the 1M / 3Y / 10Y / 20Y / 30Y dropouts in one shot.
2. **Tolerance 0.05 → 0.5.** Smallest inter-bucket gap is 0.5y (6M↔1Y), so 0.5y absorbs day-count / EOD-asOf wobble while keeping adjacent-bucket cross-matching structurally impossible. Also eliminates 3M's silent cross-match.

## Verification

### Existing regression spec (`tests/e2e/curves-pages-render.spec.ts`) — all green

```
[chromium] › curves-pages-render.spec.ts:46:3  /data/curves: 200, no "Insufficient curve inputs" …  PASS
[chromium] › curves-pages-render.spec.ts:96:3  /data/treasury_curve: row count in [8, 11] range … PASS
[chromium] › curves-pages-render.spec.ts:150:3 /data/treasury_curve part B: par yields rendered … PASS
[chromium] › curves-pages-render.spec.ts:214:3 /data/treasury_curve part C: no POST*/TEST* …      PASS
  5 passed (5.1s)
```

The part-B spec already locks the "every priced row must have a non-null Par Yield" assertion the cherry-picked commit added — pre-fix it would have failed loudly with 4 of 9 offenders on the older repro, and 5 of 11 on the current 2026-05-14 repro.

### Scratch probe at exactly date=2026-05-14 (the user's repro date)

Ran a one-off probe against the running UI server. Output of `npx playwright test probe-315.spec.ts`:

```
[#315 probe — /data/treasury_curve?date=2026-05-14]
Tenor   CUSIP        Coupon   Price      Par Yield
1M      912797UR6    0.000%   99.2662    3.650%
3M      912797VB0    0.000%   98.8368    3.718%
6M      912797UY1    0.000%   98.1850    3.742%
1Y      912797UX3    0.000%   96.3297    3.821%
2Y      91282CQL8    3.750%   99.5313    3.996%
3Y      91282CQJ3    3.875%   99.5625    4.031%
5Y      91282CQK0    3.875%   98.8750    4.126%
7Y      91282CQN4    4.125%   99.0000    4.292%
10Y     91282CPZ8    4.125%   97.3438    4.457%
20Y     912810UT3    4.625%   95.0938    5.016%
30Y     912810UR7    4.750%   95.7813    5.024%
```

11 / 11 priced rows now have a par yield. No `—`. Curve shape monotone upward (3.65 → 5.02% over 1M → 30Y, ~135 bps term premium), no flat segments. The probe spec was not committed — it's a one-off for this PR's verification trail.

### Gates

- `svelte-check`: 83 errors, 205 warnings — **unchanged baseline** (committed errors pre-exist).
- Playwright: 5 / 5 green.
- (Vitest unit suite not re-run — cherry-pick is `src/lib/runCurve.ts` + `tests/e2e/*.spec.ts` only; no unit-test surface touched.)

## Cross-references

- second-brain#315 — diagnostic comment with per-row trace: https://github.com/FinTekkers/second-brain/issues/315#issuecomment-4464715048
- second-brain#305 (reopen) — original diagnosis + fix authored on the now-unmerged feature/305 branch.
- second-brain#314 — landed the real-CUSIP fix for the 5Y/10Y bucket bodies; #315 is the join-side follow-up that picks up the resulting 11-priced state.

## Test plan

- [ ] Wait for backend-dev-valuation's #315 (3) probe — confirms fitter emits at actual maturity-years.
- [ ] If their numbers agree with the table above: PM merges; I post-verify on `main` and close the issue.
- [ ] If their numbers disagree: hold this PR; re-diagnose as case (b).
- [x] curves-pages-render.spec.ts (5 / 5 PASS).
- [x] scratch probe at date=2026-05-14 (11 / 11 priced rows yield a par yield).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
