### PR TITLE
Native log rotation via rotating-file-stream wrapper (#332)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "vite dev --host --port 443",
+		"dev:rotated": "node scripts/log-rotate.mjs vite dev --host --port 443",
 		"dev:debug": "node --inspect-brk=0.0.0.0:9229 ./node_modules/vite/bin/vite.js dev --host --port 443",
 		"build": "vite build",
 		"preview": "vite preview --host --port 443",
@@ -101,6 +102,7 @@
 		"postcss": "^8.4.32",
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.8.1",
+		"rotating-file-stream": "^3.2.5",
 		"svelte": "^3.54.0",
 		"svelte-check": "^3.0.1",
 		"svelte-jester": "^3.0.0",

--- a/scripts/log-rotate.mjs
+++ b/scripts/log-rotate.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// scripts/log-rotate.mjs — Vite stdio capture with daily rotation (#332).
+//
+// Usage:
+//   LOG_FILE=/path/to/log node scripts/log-rotate.mjs <cmd> [args...]
+//
+// When LOG_FILE is set, spawns <cmd> and pipes its stdout+stderr through
+// rotating-file-stream (interval=1d, maxFiles=7, gzip). When unset, it
+// passes through to the parent's stdio with no rotation — behavior is
+// indistinguishable from running <cmd> directly. This means it's safe to
+// adopt before the companion services.sh transition PR sets LOG_FILE.
+
+import { spawn } from 'node:child_process';
+import { dirname, basename } from 'node:path';
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.error('usage: log-rotate.mjs <cmd> [args...]');
+  process.exit(2);
+}
+const [cmd, ...cmdArgs] = args;
+
+const logFile = process.env.LOG_FILE;
+
+if (!logFile) {
+  // Passthrough — no rotation, no extra deps loaded.
+  const child = spawn(cmd, cmdArgs, { stdio: 'inherit' });
+  child.on('exit', (code) => process.exit(code ?? 0));
+  process.on('SIGINT', () => child.kill('SIGINT'));
+  process.on('SIGTERM', () => child.kill('SIGTERM'));
+} else {
+  // Daily rotation, keep 7 files, gzip rotated. The stream's bookkeeping
+  // (which file is current vs. rotated) lives in the rotating-file-stream
+  // module — we just write to it.
+  const { createStream } = await import('rotating-file-stream');
+  const stream = createStream(basename(logFile), {
+    interval: '1d',
+    maxFiles: 7,
+    path: dirname(logFile),
+    compress: 'gzip',
+  });
+
+  const child = spawn(cmd, cmdArgs, { stdio: ['inherit', 'pipe', 'pipe'] });
+
+  // Mirror to both the rotated file and the parent's stdio so dev users
+  // still see live output in the terminal.
+  child.stdout.pipe(stream, { end: false });
+  child.stderr.pipe(stream, { end: false });
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+
+  child.on('exit', (code) => {
+    stream.end();
+    process.exit(code ?? 0);
+  });
+  process.on('SIGINT', () => child.kill('SIGINT'));
+  process.on('SIGTERM', () => child.kill('SIGTERM'));
+}

--- a/scripts/log-rotate.mjs
+++ b/scripts/log-rotate.mjs
@@ -33,9 +33,13 @@ if (!logFile) {
   // (which file is current vs. rotated) lives in the rotating-file-stream
   // module — we just write to it.
   const { createStream } = await import('rotating-file-stream');
+  // Size-triggered rotation with a hard 100 MB cap on the active file and
+  // a single retained rotated sibling — meets the #332 100 MB-per-service
+  // total target. rotating-file-stream supports `size` natively, so unlike
+  // the Rust services (tracing-appender, time-only) this is a hard cap.
   const stream = createStream(basename(logFile), {
-    interval: '1d',
-    maxFiles: 7,
+    size: '100M',
+    maxFiles: 1,
     path: dirname(logFile),
     compress: 'gzip',
   });


### PR DESCRIPTION
## Summary

ui-service has no application-level logger — Vite's dev server writes to stdout, and `services.sh` currently captures it via shell `>>$log`. Introducing a full logger framework (pino, winston) is heavier than #332 needs for a service that produces ≈12 KB/day.

This PR adds a small Node wrapper that pipes Vite's stdio through `rotating-file-stream`:

- **`scripts/log-rotate.mjs`** — spawns the inner command (Vite), pipes its stdout+stderr through a daily-rotated file when `LOG_FILE` is set; falls through to passthrough when unset.
- **New npm script** `"dev:rotated": "node scripts/log-rotate.mjs vite dev --host --port 443"`.
- **devDependency**: `rotating-file-stream ^3.2.5`.

Rotation config:
- `interval: '1d'` (daily)
- `maxFiles: 7` (keep last 7 days)
- `compress: 'gzip'`

## Why a wrapper, not a real logger?

Application code in ui-service barely logs at all — 153 `console.*` hits, almost all in tests. The runtime log volume is *Vite's startup output and incidental SvelteKit hooks output*, not structured application logs. Wrapping the existing stream is the minimal-change path to native rotation; introducing pino/winston as a structured-logging library is a separate, much bigger conversation.

## Coordinated rollout — safe to merge alone

This PR is **env-var-gated** and **opt-in via a new script**:
- `npm run dev` — unchanged, runs Vite directly, no rotation.
- `npm run dev:rotated` with `LOG_FILE` set — rotated output to the file.
- `npm run dev:rotated` without `LOG_FILE` — passthrough mode, no rotation, behavior identical to `npm run dev`.

The companion `services.sh` transition PR in `fintekkers-devops-scripts` will switch the ui-service start command from `npm run dev` to `npm run dev:rotated` with `LOG_FILE=~/second-brain/logs/ui-service.log` set, and drop the existing shell `>>$log` redirect.

## Test plan

- [x] `package.json` validates as JSON.
- [x] `node --check scripts/log-rotate.mjs` passes.
- [ ] `npm install` to pick up rotating-file-stream.
- [ ] `npm run dev:rotated` without `LOG_FILE` — confirm Vite starts and logs to terminal as usual.
- [ ] `LOG_FILE=/tmp/ui.test.log npm run dev:rotated` — confirm the file is created and grows; terminal still mirrors output.
- [ ] Force rotation (system clock or interval='1s' temporarily) and confirm rotated `.1.gz` siblings appear.