### PR TITLE
chore: sync package-lock.json with rotating-file-stream (#332 follow-up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
 				"postcss": "^8.4.32",
 				"prettier": "^2.8.0",
 				"prettier-plugin-svelte": "^2.8.1",
+				"rotating-file-stream": "^3.2.5",
 				"svelte": "^3.54.0",
 				"svelte-check": "^3.0.1",
 				"svelte-jester": "^3.0.0",
@@ -17248,6 +17249,19 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/rotating-file-stream": {
+			"version": "3.2.9",
+			"resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-3.2.9.tgz",
+			"integrity": "sha512-i9i0KkHh12ryl4xtELg+0gyoFre2PJ9RcQQLzquWsiqygyYsrZLckrqqYrthhnJZGZb4g+KUHtcoWYVq34gaug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0"
+			},
+			"funding": {
+				"url": "https://www.blockchain.com/btc/address/12p1p5q7sK75tPyuesZmssiMYr4TKzpSCN"
 			}
 		},
 		"node_modules/rrweb-cssom": {


### PR DESCRIPTION
## Summary

Fix-forward: PR #185 added \`rotating-file-stream@^3.2.5\` to \`package.json\` but the lockfile wasn't regenerated, so \`main\` CI fails the lockfile sync check.

This PR is a single \`npm install --ignore-scripts\` run on top of \`main\`, which adds the resolved entries for \`rotating-file-stream@3.2.9\` (matches the \`^3.2.5\` constraint, latest stable per \`npm view\`).

## Diff scope

```
package-lock.json | 14 ++++++++++++++
1 file changed, 14 insertions(+)
```

No other dependencies shift. No \`package.json\` changes.

## Test plan

- [x] \`grep -c rotating-file-stream package-lock.json\` now returns 3 (was 0).
- [ ] CI lockfile sync passes.