### PR TITLE
fix(#313): join all identifiers for display; UUID only when none present

### DIFF
--- a/src/lib/security.test.ts
+++ b/src/lib/security.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for identifierString + primaryIdentifier (#313).
+ *
+ * Pre-fix `identifierString` hardcoded CUSIP→ISIN→UUID and silently
+ * rendered the UUID hex on /data/securities for every equity / index /
+ * currency row. PM redirect (issue #313 comments): skip the per-product
+ * priority chain for display — join every identifier value instead.
+ * `primaryIdentifier` keeps the per-family preference for the lookup /
+ * filter paths that genuinely need a single value.
+ */
+import { describe, expect, test } from 'vitest';
+import Security from '@fintekkers/ledger-models/node/wrappers/models/security/security';
+import { SecurityProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/security_pb';
+import { ProductTypeProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/product_type_pb';
+import { IdentifierProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/identifier/identifier_pb';
+import { IdentifierTypeProto } from '@fintekkers/ledger-models/node/fintekkers/models/security/identifier/identifier_type_pb';
+import { UUID } from '@fintekkers/ledger-models/node/wrappers/models/utils/uuid';
+
+import { primaryIdentifier, identifierString } from './security';
+
+function buildSecurity(
+  productType: number,
+  ids: Array<{ type: IdentifierTypeProto; value: string }>,
+): Security {
+  const proto = new SecurityProto()
+    .setObjectClass('Security')
+    .setVersion('0.0.1')
+    .setUuid(UUID.random().toUUIDProto())
+    .setProductType(productType)
+    .setIssuerName('Test Issuer');
+  for (const id of ids) {
+    proto.addIdentifiers(
+      new IdentifierProto().setIdentifierType(id.type).setIdentifierValue(id.value),
+    );
+  }
+  return Security.create(proto);
+}
+
+describe('identifierString (#313) — join all identifiers', () => {
+  test('single-identifier security renders as just that identifier', () => {
+    const sec = buildSecurity(ProductTypeProto.COMMON_STOCK, [
+      { type: IdentifierTypeProto.EXCH_TICKER, value: 'TSLA' },
+    ]);
+    expect(identifierString(sec)).toBe('TSLA');
+  });
+
+  test('multi-identifier security joins every value with ", "', () => {
+    // Order matches insertion order — we don't sort, so the wire order
+    // determines display order. Treasuries today carry CUSIP first.
+    const sec = buildSecurity(ProductTypeProto.TREASURY_NOTE, [
+      { type: IdentifierTypeProto.CUSIP, value: '91282CQL8' },
+      { type: IdentifierTypeProto.ISIN, value: 'US91282CQL81' },
+    ]);
+    expect(identifierString(sec)).toBe('91282CQL8, US91282CQL81');
+  });
+
+  test('equity rows render their ticker (regression guard for #313)', () => {
+    // Pre-fix: equities fell through CUSIP/ISIN to UUID hex. The fix is
+    // that EXCH_TICKER (the only identifier on the row) renders.
+    const sec = buildSecurity(ProductTypeProto.COMMON_STOCK, [
+      { type: IdentifierTypeProto.EXCH_TICKER, value: 'TSLA' },
+    ]);
+    const result = identifierString(sec);
+    expect(result).toBe('TSLA');
+    expect(result).not.toMatch(/^[0-9a-f-]{36}$/i);
+  });
+
+  test('currency rows render the CASH 3-letter code, not the UUID', () => {
+    const sec = buildSecurity(ProductTypeProto.CURRENCY, [
+      { type: IdentifierTypeProto.CASH, value: 'USD' },
+    ]);
+    expect(identifierString(sec)).toBe('USD');
+  });
+
+  test('index rows render their SERIES_ID, not the UUID', () => {
+    const sec = buildSecurity(ProductTypeProto.CPI_SERIES, [
+      { type: IdentifierTypeProto.SERIES_ID, value: 'CUSR0000SA0' },
+    ]);
+    expect(identifierString(sec)).toBe('CUSR0000SA0');
+  });
+
+  test('UUID fallback fires only when no identifiers are present at all', () => {
+    const sec = buildSecurity(ProductTypeProto.COMMON_STOCK, []);
+    const result = identifierString(sec);
+    // UUID stringifies to the canonical 36-char hyphenated form — the
+    // shape /data/securities used to render for every equity row.
+    expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+});
+
+describe('primaryIdentifier (#313) — per-product-family preference', () => {
+  test('TREASURY_NOTE bond prefers CUSIP over ISIN', () => {
+    const sec = buildSecurity(ProductTypeProto.TREASURY_NOTE, [
+      { type: IdentifierTypeProto.ISIN, value: 'US91282CQL81' },
+      { type: IdentifierTypeProto.CUSIP, value: '91282CQL8' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('91282CQL8');
+  });
+
+  test('MORTGAGE_BACKED bond family also resolves to CUSIP', () => {
+    const sec = buildSecurity(ProductTypeProto.MORTGAGE_BACKED, [
+      { type: IdentifierTypeProto.CUSIP, value: '3133WJVX4' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('3133WJVX4');
+  });
+
+  test('CORP_BOND with only ISIN falls through CUSIP to ISIN', () => {
+    const sec = buildSecurity(ProductTypeProto.CORP_BOND, [
+      { type: IdentifierTypeProto.ISIN, value: 'XS1234567890' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('XS1234567890');
+  });
+
+  test('COMMON_STOCK (equity) prefers EXCH_TICKER over CUSIP/ISIN', () => {
+    const sec = buildSecurity(ProductTypeProto.COMMON_STOCK, [
+      { type: IdentifierTypeProto.CUSIP, value: '88160R101' },
+      { type: IdentifierTypeProto.ISIN, value: 'US88160R1014' },
+      { type: IdentifierTypeProto.EXCH_TICKER, value: 'TSLA' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('TSLA');
+  });
+
+  test('ETF prefers EXCH_TICKER', () => {
+    const sec = buildSecurity(ProductTypeProto.ETF, [
+      { type: IdentifierTypeProto.EXCH_TICKER, value: 'SPY' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('SPY');
+  });
+
+  test('CPI_SERIES (index) prefers SERIES_ID over UUID', () => {
+    const sec = buildSecurity(ProductTypeProto.CPI_SERIES, [
+      { type: IdentifierTypeProto.SERIES_ID, value: 'CUSR0000SA0' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('CUSR0000SA0');
+  });
+
+  test('EQUITY_INDEX prefers SERIES_ID', () => {
+    const sec = buildSecurity(ProductTypeProto.EQUITY_INDEX, [
+      { type: IdentifierTypeProto.SERIES_ID, value: 'SPX' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('SPX');
+  });
+
+  test('CURRENCY prefers CASH identifier (3-letter code)', () => {
+    const sec = buildSecurity(ProductTypeProto.CURRENCY, [
+      { type: IdentifierTypeProto.CASH, value: 'USD' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('USD');
+  });
+
+  test('CRYPTOCURRENCY prefers EXCH_TICKER', () => {
+    const sec = buildSecurity(ProductTypeProto.CRYPTOCURRENCY, [
+      { type: IdentifierTypeProto.EXCH_TICKER, value: 'BTC' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('BTC');
+  });
+
+  test('any-present-identifier fallback when the preferred type is missing', () => {
+    // COMMON_STOCK normally prefers EXCH_TICKER; an off-convention write
+    // with only an OSI identifier should still surface OSI rather than
+    // falling all the way to undefined.
+    const sec = buildSecurity(ProductTypeProto.COMMON_STOCK, [
+      { type: IdentifierTypeProto.OSI, value: 'OSI_FALLBACK_123' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('OSI_FALLBACK_123');
+  });
+
+  test('returns undefined when no identifiers are present', () => {
+    const sec = buildSecurity(ProductTypeProto.COMMON_STOCK, []);
+    expect(primaryIdentifier(sec)).toBeUndefined();
+  });
+
+  test('unknown product type defaults to bond order (CUSIP first)', () => {
+    const sec = buildSecurity(ProductTypeProto.PRODUCT_TYPE_UNKNOWN, [
+      { type: IdentifierTypeProto.CUSIP, value: '999999999' },
+      { type: IdentifierTypeProto.EXCH_TICKER, value: 'XXX' },
+    ]);
+    expect(primaryIdentifier(sec)?.getIdentifierValue()).toBe('999999999');
+  });
+});

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -111,20 +111,113 @@ export function productTypeNameOf(security: Security): string {
   return found?.[0] ?? 'UNKNOWN_PRODUCT_TYPE';
 }
 
-// Identifier lookup helpers. The wrapper's typed lookup
-// `Security.getIdentifierByType(type)` returns `Identifier | undefined`,
-// which lets callers express the canonical "CUSIP, else ISIN, else
-// fall back to UUID" chain inline. These helpers package that chain so
-// the call sites stay short.
+// Identifier helpers.
+//
+// `identifierString` is for display — it joins every identifier value
+// attached to the security (comma-separated). Single-identifier rows
+// look identical to the pre-fix behavior; multi-identifier rows (e.g. a
+// Treasury with both CUSIP and ISIN) surface both rather than picking
+// one and hiding the other. The UUID hex only appears when the security
+// genuinely has no identifiers — a data-hygiene marker, not a default.
+//
+// `primaryIdentifier` is for code paths that need a single identifier
+// (lookups, search filters, the per-row identifierType column on the
+// /data/securities grid). It dispatches per product family — bonds
+// prefer CUSIP→ISIN, equities prefer EXCH_TICKER, etc. — and falls back
+// to the first present identifier before returning undefined.
+//
+// #313: the pre-fix `identifierString` hardcoded CUSIP→ISIN→UUID, which
+// silently rendered the UUID hex on /data/securities + every downstream
+// consumer for every non-bond product (equities, indices, currencies).
+const BOND_ORDER: readonly IdentifierTypeProto[] =
+  [IdentifierTypeProto.CUSIP, IdentifierTypeProto.ISIN, IdentifierTypeProto.FIGI];
+const EQUITY_ORDER: readonly IdentifierTypeProto[] =
+  [IdentifierTypeProto.EXCH_TICKER, IdentifierTypeProto.ISIN, IdentifierTypeProto.FIGI, IdentifierTypeProto.CUSIP];
+const INDEX_ORDER: readonly IdentifierTypeProto[] =
+  [IdentifierTypeProto.SERIES_ID, IdentifierTypeProto.INDEX_NAME];
+const CURRENCY_ORDER: readonly IdentifierTypeProto[] =
+  [IdentifierTypeProto.CASH];
+const COMMODITY_OR_CRYPTO_ORDER: readonly IdentifierTypeProto[] =
+  [IdentifierTypeProto.EXCH_TICKER, IdentifierTypeProto.ISIN, IdentifierTypeProto.FIGI];
+
+function preferenceOrderFor(productType: number): readonly IdentifierTypeProto[] {
+  switch (productType) {
+    // Bond family — CUSIP first (the US convention; non-US bonds in
+    // the ledger today still get CUSIPs from FedInvest / dealer feeds
+    // where present, ISIN as the international fallback).
+    case ProductTypeProto.TBILL:
+    case ProductTypeProto.TREASURY_NOTE:
+    case ProductTypeProto.TREASURY_BOND:
+    case ProductTypeProto.TIPS:
+    case ProductTypeProto.TREASURY_FRN:
+    case ProductTypeProto.STRIPS:
+    case ProductTypeProto.SOVEREIGN_BOND:
+    case ProductTypeProto.CORP_BOND:
+    case ProductTypeProto.MUNI_BOND:
+    case ProductTypeProto.MORTGAGE_BACKED:
+      return BOND_ORDER;
+    // Equity family — exchange ticker first.
+    case ProductTypeProto.COMMON_STOCK:
+    case ProductTypeProto.PREFERRED_STOCK:
+    case ProductTypeProto.ADR:
+    case ProductTypeProto.ETF:
+      return EQUITY_ORDER;
+    // Index family — SERIES_ID first, INDEX_NAME as the human-readable
+    // fallback for the few indices that don't carry a programmatic ID.
+    case ProductTypeProto.EQUITY_INDEX:
+    case ProductTypeProto.BOND_INDEX:
+    case ProductTypeProto.COMMODITY_INDEX:
+    case ProductTypeProto.VIX_SPOT:
+    case ProductTypeProto.CPI_SERIES:
+    case ProductTypeProto.SOFR_SERIES:
+      return INDEX_ORDER;
+    // Currency family — CASH identifier carries the 3-letter code.
+    case ProductTypeProto.CURRENCY:
+    case ProductTypeProto.FX_SPOT:
+    case ProductTypeProto.MONEY_MARKET_FUND:
+      return CURRENCY_ORDER;
+    // Crypto / commodity — exchange ticker is the dominant convention.
+    case ProductTypeProto.CRYPTOCURRENCY:
+    case ProductTypeProto.STABLECOIN:
+    case ProductTypeProto.GOLD:
+    case ProductTypeProto.SILVER:
+      return COMMODITY_OR_CRYPTO_ORDER;
+    default:
+      return BOND_ORDER;
+  }
+}
+
 export function primaryIdentifier(security: Security): Identifier | undefined {
-  return (
-    security.getIdentifierByType(IdentifierTypeProto.CUSIP) ??
-    security.getIdentifierByType(IdentifierTypeProto.ISIN)
-  );
+  // Skip the wrapper's typed lookup on link-mode Securities (it throws);
+  // index lookthrough fan-out hands us those mid-pipeline.
+  if (security.proto.getIsLink()) return undefined;
+
+  const productType = security.proto.getProductType();
+  const order = preferenceOrderFor(productType);
+
+  for (const type of order) {
+    const found = security.getIdentifierByType(type);
+    if (found) return found;
+  }
+
+  // Per-family preference list missed — try any other identifier present
+  // before falling back to the UUID. Catches off-convention writes (e.g.
+  // an equity row that only got an OSI for some reason) so the user
+  // sees a human-readable string instead of UUID hex.
+  const all = security.getIdentifiers();
+  if (all.length > 0) return all[0];
+  return undefined;
 }
 
 export function identifierString(security: Security): string {
-  return primaryIdentifier(security)?.getIdentifierValue() ?? security.getID().toString();
+  // Skip the typed-list lookup on link-mode Securities (wrapper throws);
+  // index lookthrough fan-out hands us those mid-pipeline. Fall through
+  // to the UUID, which is the only field a link-mode row carries.
+  if (security.proto.getIsLink()) return security.getID().toString();
+
+  const ids = security.getIdentifiers();
+  if (ids.length === 0) return security.getID().toString();
+  return ids.map((id) => id.getIdentifierValue()).join(', ');
 }
 
 function identifierTypeNameToProto(name: IdentifierTypeName): IdentifierTypeProto {

--- a/tests/e2e/securities-identifier-render.spec.ts
+++ b/tests/e2e/securities-identifier-render.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * #313: /data/securities was rendering UUID hex (e.g.
+ * "1f3a2b9c-…-d2") in the Identifier column for every non-bond
+ * product because `primaryIdentifier` hardcoded CUSIP→ISIN→UUID. With
+ * the per-product-family fix, equities should now show their exchange
+ * ticker.
+ *
+ * This guard fails loudly if the bug ever regresses by asserting
+ * the Identifier cell of an equity row matches the ticker shape
+ * (1-5 upper-case letters) rather than a UUID.
+ */
+import { test, expect } from '@playwright/test';
+
+// Look up an equity directly by exchange ticker. Pre-fix this row's
+// Identifier column rendered as the UUID hex; post-fix it should
+// render as TSLA. Using a specific identifier avoids the assetClass /
+// productType post-filter quirks on /data/securities (assetClass
+// validation rejects legacy capitalizations, productType has no
+// server-side filter so a productType-only query is empty and ledger
+// rejects it). The seeded TSLA row is the same one /data/prices's
+// autocomplete test relies on.
+const EQUITIES_URL = '/data/securities?identifier=TSLA&identifierType=EXCH_TICKER';
+
+const TICKER_SHAPE = /^[A-Z][A-Z0-9.]{0,5}$/;
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+test.describe('/data/securities identifier column (#313)', () => {
+  test('equity rows render exchange ticker, not UUID', async ({ page }) => {
+    const response = await page.goto(EQUITIES_URL);
+    expect(response, 'GET /data/securities returns a response').not.toBeNull();
+    expect(response!.status(), 'no 5xx — load() must not throw').toBeLessThan(500);
+
+    // Wait for the grid to render at least one row. SecurityGrid lays
+    // each row out as `<tr>` with the first `<td>` (action column) +
+    // the Identifier column second.
+    const rows = page.locator('table tbody tr');
+    await expect.poll(async () => rows.count(), { timeout: 15_000 }).toBeGreaterThan(0);
+
+    const rowCount = await rows.count();
+    const samples: { identifier: string; idType: string }[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const cells = rows.nth(i).locator('td');
+      // td 0 = action column, td 1 = Identifier value, td 2 = ID Type.
+      const identifier = (await cells.nth(1).innerText()).trim();
+      const idType = (await cells.nth(2).innerText()).trim();
+      samples.push({ identifier, idType });
+    }
+
+    // Pre-fix every equity row would have an Identifier cell shaped
+    // like a UUID. Post-fix every row should match the ticker shape.
+    const uuidRows = samples.filter((r) => UUID_SHAPE.test(r.identifier));
+    expect(
+      uuidRows,
+      `equity rows rendering as UUID (regression of #313): ${JSON.stringify(uuidRows)}`,
+    ).toEqual([]);
+
+    const tickerRows = samples.filter((r) => TICKER_SHAPE.test(r.identifier));
+    expect(
+      tickerRows.length,
+      `expected at least one equity row to render a ticker — got ${JSON.stringify(samples)}`,
+    ).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Rewrites `identifierString` to join every identifier value on the security (comma-separated), so equities / indices / currencies / MBS / options stop falling through to a UUID-hex render on `/data/securities` and every downstream page.
- Keeps `primaryIdentifier` with a per-product-family preference order (bonds → CUSIP→ISIN, equities → EXCH_TICKER, indices → SERIES_ID, currencies → CASH, …) for code paths that still need a single picked identifier — search filters, the per-row identifierType column on `/data/securities`, the CPI-index lookup.
- Adds 18 vitest cases on join + per-family behavior and a Playwright regression guard on `/data/securities` rendering TSLA (not a UUID).

## Why

`identifierString` was the single source of the bug: `CUSIP ?? ISIN ?? UUID`. Every non-bond product silently rendered its UUID hex. PM redirect on the issue: skip the per-product-type priority chain for display — show every identifier instead. Single-identifier rows (the vast majority) look identical to the pre-fix output; multi-identifier rows surface both (no info loss).

## Closes

FinTekkers/second-brain#313

## Test plan

- [x] `npx vitest run` — 426 passed (38 files), including 18 new tests in `src/lib/security.test.ts`
- [x] `npx svelte-check` — 83 errors / 205 warnings (no change vs. baseline on `main`)
- [x] `npx playwright test tests/e2e/securities-identifier-render.spec.ts` — passes (asserts the equity row renders `TSLA`, not a UUID)
- [x] `npx playwright test` — 64 passed / 4 pre-existing failures unrelated to identifier rendering (portfolio SOMA nav, default-issuer #306, TIPS calculator #263, transactions portfolio columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)