### PR TITLE
fix(#348): swap Vite dev → adapter-node prod build; trust ALB forwarded scheme

### DIFF
--- a/build_deploy.py
+++ b/build_deploy.py
@@ -112,22 +112,51 @@ def deploy_code_to_instance(instance_id: str) -> bool:
         "pwd",
         "pwd",
         "cd /home/ec2-user/ui-service;npm install",
-        # Build the production server, the variables are required to build
-        # TEMP HACK TODO TODO TODO ###############"cd /home/ec2-user/ui-service;GOOGLE_CLIENT_ID=MISSING GOOGLE_CLIENT_SECRET=MISSING npm run build",
-        # Set the port to be 443. Note this is running HTTP server but running on HTTPS port.
-        # The load balancer on AWS will add the encryption/certificate termination and forward
-        # to this port. We could expose to port 80, but the broker is already using that port
-        # Run the production server
-        # CONTACT_GMAIL_APP_PASSWORD contains spaces (the 4×4 group
-        # format Google emits), so single-quote-wrap it inside the
-        # outer double-quoted pm2 start argument.
-        'cd /home/ec2-user/ui-service;sudo PORT=443 ORIGIN=https://www.fintekkers.org pm2 start "GOOGLE_CLIENT_ID='
+        # #348: run the ACTUAL production build now (adapter-node). The
+        # earlier deploy script fell back to `npm run dev` in prod
+        # because the build was failing — that root cause is fixed in
+        # this commit (contactus template TS-cast + vite.config.ts
+        # ssr.noExternal for ledger-models + transitive proto/grpc deps).
+        # Build needs Google OAuth env vars available at build time
+        # (SvelteKit inlines process.env references into the bundle).
+        'cd /home/ec2-user/ui-service;GOOGLE_CLIENT_ID='
         + GOOGLE_CLIENT_ID
         + " GOOGLE_CLIENT_SECRET="
         + GOOGLE_CLIENT_SECRET
         + f" CONTACT_GMAIL_USER='{CONTACT_GMAIL_USER}'"
         + f" CONTACT_GMAIL_APP_PASSWORD='{CONTACT_GMAIL_APP_PASSWORD}'"
-        + ' npm run dev"',  # Needs sudo to expose host; currently running dev because the build fails... unsure why!!!
+        + " npm run build",
+        # #348 CSRF fix: run `node build` (adapter-node prod server) with
+        #   PROTOCOL_HEADER=x-forwarded-proto
+        #   HOST_HEADER=x-forwarded-host
+        # so SvelteKit computes its origin from what the ALB forwards
+        # (https://www.fintekkers.org) instead of the plain-HTTP hop from
+        # the ALB to Node. Without this, browser Origin=https://... vs
+        # SvelteKit-computed origin=http://... → CSRF 403 on every login
+        # POST. This is safe *only* because (a) the ALB overwrites
+        # X-Forwarded-Proto and X-Forwarded-Host on incoming traffic,
+        # and (b) the Node port on this instance is reachable only via
+        # the ALB target group — do NOT open the instance port to the
+        # public internet, or a client could spoof these headers.
+        # Deliberately dropping the static ORIGIN=... env from the old
+        # command: forwarded-headers covers www + api and survives host
+        # changes (per #348 spec).
+        # Port 443 keeps the target-group config unchanged (ALB → 443).
+        # CONTACT_GMAIL_APP_PASSWORD contains spaces (Google's 4×4 group
+        # format), so single-quote it inside the outer pm2 arg string.
+        'cd /home/ec2-user/ui-service;sudo PORT=443'
+        + " PROTOCOL_HEADER=x-forwarded-proto"
+        + " HOST_HEADER=x-forwarded-host"
+        + ' pm2 start "GOOGLE_CLIENT_ID='
+        + GOOGLE_CLIENT_ID
+        + " GOOGLE_CLIENT_SECRET="
+        + GOOGLE_CLIENT_SECRET
+        + f" CONTACT_GMAIL_USER='{CONTACT_GMAIL_USER}'"
+        + f" CONTACT_GMAIL_APP_PASSWORD='{CONTACT_GMAIL_APP_PASSWORD}'"
+        + " PORT=443"
+        + " PROTOCOL_HEADER=x-forwarded-proto"
+        + " HOST_HEADER=x-forwarded-host"
+        + ' node build"',
     ]
 
     ssh_connect_with_retry(ssh, ip_address, 0)

--- a/src/routes/contactus/+page.svelte
+++ b/src/routes/contactus/+page.svelte
@@ -25,6 +25,17 @@
         });
     };
 
+    // #348: Svelte's template parser (v3/4) doesn't accept inline TS
+    // casts like `(event.target as HTMLInputElement).value` in attribute
+    // expressions, even under `<script lang="ts">`. That's the reason
+    // the build was failing and prod was falling back to `npm run dev`
+    // (see build_deploy.py comment "build fails... unsure why"). Extract
+    // the cast into a script helper so the template stays JS-parseable.
+    const inputChangeValue = (fieldName: string, event: Event) => {
+        const target = event.target as HTMLInputElement | HTMLTextAreaElement | null;
+        handleChange(fieldName, target?.value ?? "");
+    };
+
     // displaying errors from form
     const displayError = (fieldName: string) => {
         isTypingField.update((store) => {
@@ -77,8 +88,7 @@
                 </span>
                 <input
                     on:focus={() => handleFocus("firstname")}
-                    on:change={(event) =>
-                        handleChange("firstname", (event.target as HTMLInputElement).value)}
+                    on:change={(event) => inputChangeValue("firstname", event)}
                     on:blur={() => handleBlur("firstname")}
                     id="firstname"
                     name="firstname"
@@ -104,8 +114,7 @@
                 </span>
                 <input
                     on:focus={() => handleFocus("lastname")}
-                    on:change={(event) =>
-                        handleChange("lastname", (event.target as HTMLInputElement).value)}
+                    on:change={(event) => inputChangeValue("lastname", event)}
                     on:blur={() => handleBlur("lastname")}
                     id="lastname"
                     name="lastname"
@@ -130,8 +139,7 @@
                 </span>
                 <input
                     on:focus={() => handleFocus("email")}
-                    on:change={(event) =>
-                        handleChange("email", (event.target as HTMLInputElement).value)}
+                    on:change={(event) => inputChangeValue("email", event)}
                     on:blur={() => handleBlur("email")}
                     id="email"
                     type="email"
@@ -156,8 +164,7 @@
                 </span>
                 <textarea
                     on:focus={() => handleFocus("message")}
-                    on:change={(event) =>
-                        handleChange("message", (event.target as HTMLTextAreaElement).value)}
+                    on:change={(event) => inputChangeValue("message", event)}
                     on:blur={() => handleBlur("message")}
                     id="message"
                     name="message"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,41 @@ export default defineConfig({
       },
     },
   },
+  // #348: bundle @fintekkers/ledger-models + google-protobuf into the
+  // SSR output. Both packages ship legacy CommonJS with
+  // `goog.object.extend(exports, proto.<namespace>)` — Node's ESM/CJS
+  // interop (cjs-module-lexer) can't statically detect those exports,
+  // so `node build` fails during SvelteKit's analyse step with
+  // "does not provide an export named 'GetFieldValuesRequestProto'"
+  // (and every other proto class). vite dev works because esbuild
+  // handles CJS at request time. `ssr.noExternal` tells vite to bundle
+  // these deps into the SSR output too, so the built server file
+  // contains the CJS bodies directly and there's nothing to re-import
+  // through Node's ESM loader. This is the fix that lets the prod
+  // build actually run — before this the deploy fell back to
+  // `npm run dev` (see build_deploy.py "build fails... unsure why").
+  ssr: {
+    // Bundle ledger-models + every transitive dep it `require()`s into
+    // the SSR output. Vite/esbuild rewrites those `require()` calls into
+    // `import require$$N from '<dep>'` — modern ESM-only deps (uuid v9,
+    // luxon, decimal.js, dotenv) don't have a default export, so the
+    // synthesised default import fails at Node's analyse step. Listing
+    // each here lets vite bundle them and rewrite the access into
+    // named-import form.
+    noExternal: [
+      '@fintekkers/ledger-models',
+      'google-protobuf',
+      'uuid',
+      'luxon',
+      'decimal.js',
+      'dotenv',
+      'bytebuffer',
+      '@grpc/grpc-js',
+      '@grpc/proto-loader',
+      '@js-sdsl/ordered-map',
+      /^@protobufjs\//,
+    ],
+  },
   server: {
     allowedHosts: true,
     headers: {


### PR DESCRIPTION
Fixes #348 (login 403 CSRF).

## Root cause

UI on EC2 was running `npm run dev` (Vite dev server) in prod because the prod build was failing — the deploy script even said so: *"currently running dev because the build fails... unsure why!!!"*. With the ALB terminating TLS and forwarding plain HTTP, SvelteKit's origin computed as `http://…` while the browser sent `Origin: https://www.fintekkers.org` → every login POST hit `403 Cross-site POST form submissions are forbidden` before the login action ran.

## Fixes

### 1. Actually build (contactus template + ssr bundling)

- `src/routes/contactus/+page.svelte` — Svelte v3/4's template parser doesn't accept inline TS casts (`(event.target as HTMLInputElement).value`) in attribute expressions even under `<script lang="ts">`. Extracted the cast to a script helper.
- `vite.config.ts` — added `ssr.noExternal` for `@fintekkers/ledger-models` and every one of its transitive proto/grpc deps (google-protobuf, uuid, luxon, decimal.js, dotenv, bytebuffer, @grpc/grpc-js, @grpc/proto-loader, @js-sdsl/ordered-map, @protobufjs/*). These ship legacy CommonJS with `goog.object.extend(exports, …)` or ESM-only default-exportless shapes; Node's cjs-module-lexer can't statically detect the exports so the adapter-node analyse step blows up with `does not provide an export named 'GetFieldValuesRequestProto'` (or `'default'` for uuid/luxon/…). `vite dev` worked because esbuild handles CJS at request time. Bundling them into the SSR output inlines the CJS bodies and there's nothing to re-import through Node's ESM loader.

### 2. Trust ALB forwarded scheme/host

`build_deploy.py` — pm2 now runs `node build` (adapter-node prod server) with:

```
PORT=443
PROTOCOL_HEADER=x-forwarded-proto
HOST_HEADER=x-forwarded-host
```

Dropped the old static `ORIGIN=https://www.fintekkers.org` env — the forwarded-header approach covers `www` + `api` and survives host changes (per the #348 spec). The `npm run build` step is un-commented and runs with the Google OAuth env vars available at build time.

## Security note (preserving from spec)

Trusting the forwarded headers is only safe because (a) the ALB overwrites `X-Forwarded-Proto` and `X-Forwarded-Host` on every request, and (b) the Node port on this instance is reachable only via the ALB target group. **The instance port MUST NOT be exposed directly** — a client that could bypass the ALB could spoof the headers and defeat CSRF.

## Local reproduction (evidence)

Booted `PORT=5178 PROTOCOL_HEADER=x-forwarded-proto HOST_HEADER=x-forwarded-host node build` and POST'd `/login?/login` with `Origin: https://www.fintekkers.org`:

```
# No forwarded headers → the bug:
HTTP/1.1 403 Forbidden
Cross-site POST form submissions are forbidden

# With x-forwarded-proto: https + x-forwarded-host: www.fintekkers.org:
HTTP/1.1 200 OK
{"type":"success","status":200, …}   # CSRF check passed; login action ran
```

## Test plan

- [x] `npm run build` succeeds locally (adapter-node output in `./build`).
- [x] `node build` boots and serves.
- [x] Local CSRF repro shows the fix: 403 without headers, 200 with headers.
- [ ] Post-deploy end-to-end: log in at `https://www.fintekkers.org/login` as `testuser@fintekkers.org` (break-glass), confirm redirect to `/data/portfolios`. **Requires a `v*` tag to run `.github/workflows/deploy.yml`.** Not merging or tagging myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)